### PR TITLE
Relaunch fix

### DIFF
--- a/app/src/main/java/com/OxGames/Pluvia/ui/PluviaMain.kt
+++ b/app/src/main/java/com/OxGames/Pluvia/ui/PluviaMain.kt
@@ -208,6 +208,11 @@ fun PluviaMain(
             context.startForegroundService(intent)
         }
 
+        // Go to the Home screen if we're already logged in.
+        if (SteamService.isLoggedIn) {
+            navController.navigate(PluviaScreen.Home.name)
+        }
+
         onDispose {
             PluviaApp.events.off<AndroidEvent.SetAppBarVisibility, Unit>(onHideAppBar)
             PluviaApp.events.off<AndroidEvent.BackPressed, Unit>(onBackPressed)

--- a/app/src/main/java/com/OxGames/Pluvia/ui/model/UserLoginViewModel.kt
+++ b/app/src/main/java/com/OxGames/Pluvia/ui/model/UserLoginViewModel.kt
@@ -180,12 +180,21 @@ class UserLoginViewModel : ViewModel() {
 
     fun onRetry() {
         _loginState.update { currentState ->
-            currentState.copy(
-                isSteamConnected = SteamService.isConnected,
-                isLoggingIn = SteamService.isLoggingIn,
-                attemptCount = currentState.attemptCount.plus(1),
-                isQrFailed = false,
-            )
+            currentState.copy(isSteamConnected = SteamService.isConnected)
+            if (SteamService.isLoggedIn) {
+                // TODO: Can this be handled better?
+                // We're already logged in when 'onRetry' is called on 'init'. Show loading screen.
+                currentState.copy(
+                    isLoggingIn = true,
+                    loginResult = LoginResult.Success,
+                )
+            } else {
+                currentState.copy(
+                    isLoggingIn = SteamService.isLoggingIn,
+                    attemptCount = currentState.attemptCount.plus(1),
+                    isQrFailed = false,
+                )
+            }
         }
     }
 


### PR DESCRIPTION
Prevent going to the login screen if we're already logged in and relaunch the app when swiped away from recents.
