### PR TITLE
Add exit button to service notification.

### DIFF
--- a/app/src/main/java/com/OxGames/Pluvia/NotificationHelper.kt
+++ b/app/src/main/java/com/OxGames/Pluvia/NotificationHelper.kt
@@ -15,6 +15,8 @@ class NotificationHelper(private val context: Context) {
         private const val CHANNEL_ID = "pluvia_foreground_service"
         private const val CHANNEL_NAME = "Pluvia Foreground Service"
         private const val NOTIFICATION_ID = 1
+
+        const val ACTION_LOGOUT = "com.oxgames.pluvia.LOGOUT"
     }
 
     private val notificationManager: NotificationManager =
@@ -63,6 +65,16 @@ class NotificationHelper(private val context: Context) {
             PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
         )
 
+        val stopIntent = Intent(context, SteamService::class.java).apply {
+            action = ACTION_LOGOUT
+        }
+        val stopPendingIntent = PendingIntent.getService(
+            context,
+            0,
+            stopIntent,
+            PendingIntent.FLAG_IMMUTABLE
+        )
+
         return NotificationCompat.Builder(context, CHANNEL_ID)
             .setContentTitle(context.getString(R.string.app_name))
             .setContentText(content)
@@ -71,6 +83,7 @@ class NotificationHelper(private val context: Context) {
             .setAutoCancel(false)
             .setOngoing(true)
             .setContentIntent(pendingIntent)
+            .addAction(0, "Exit", stopPendingIntent) // 0 = no icon
             .build()
     }
 }

--- a/app/src/main/java/com/OxGames/Pluvia/NotificationHelper.kt
+++ b/app/src/main/java/com/OxGames/Pluvia/NotificationHelper.kt
@@ -16,7 +16,7 @@ class NotificationHelper(private val context: Context) {
         private const val CHANNEL_NAME = "Pluvia Foreground Service"
         private const val NOTIFICATION_ID = 1
 
-        const val ACTION_LOGOUT = "com.oxgames.pluvia.LOGOUT"
+        const val ACTION_EXIT = "com.oxgames.pluvia.EXIT"
     }
 
     private val notificationManager: NotificationManager =
@@ -66,7 +66,7 @@ class NotificationHelper(private val context: Context) {
         )
 
         val stopIntent = Intent(context, SteamService::class.java).apply {
-            action = ACTION_LOGOUT
+            action = ACTION_EXIT
         }
         val stopPendingIntent = PendingIntent.getService(
             context,

--- a/app/src/main/java/com/OxGames/Pluvia/SteamService.kt
+++ b/app/src/main/java/com/OxGames/Pluvia/SteamService.kt
@@ -36,6 +36,7 @@ import com.OxGames.Pluvia.enums.PathType
 import com.OxGames.Pluvia.enums.ReleaseState
 import com.OxGames.Pluvia.enums.SaveLocation
 import com.OxGames.Pluvia.enums.SyncResult
+import com.OxGames.Pluvia.events.AndroidEvent
 import com.OxGames.Pluvia.events.SteamEvent
 import com.OxGames.Pluvia.utils.FileUtils
 import com.OxGames.Pluvia.utils.SteamUtils
@@ -1724,6 +1725,15 @@ class SteamService : Service(), IChallengeUrlChanged {
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+
+        // Notification intents
+        when (intent?.action) {
+            NotificationHelper.ACTION_LOGOUT -> {
+                PluviaApp.events.emit(AndroidEvent.EndProcess)
+                return START_NOT_STICKY
+            }
+        }
+
         if (!isRunning) {
             logD("Using server list path: $serverListPath")
 

--- a/app/src/main/java/com/OxGames/Pluvia/SteamService.kt
+++ b/app/src/main/java/com/OxGames/Pluvia/SteamService.kt
@@ -1728,7 +1728,7 @@ class SteamService : Service(), IChallengeUrlChanged {
 
         // Notification intents
         when (intent?.action) {
-            NotificationHelper.ACTION_LOGOUT -> {
+            NotificationHelper.ACTION_EXIT -> {
                 PluviaApp.events.emit(AndroidEvent.EndProcess)
                 return START_NOT_STICKY
             }


### PR DESCRIPTION
Sometimes, you just want to easily quit the app from anywhere on the device. 

Add an "Exit" button to the foreground service notification to quit the app. This is similar to closing the app from backing out from the main screen. 