### PR TITLE
Custom crash handler

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,6 +11,7 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.READ_LOGS" />
 
     <application
         android:name=".PluviaApp"

--- a/app/src/main/java/com/OxGames/Pluvia/CrashHandler.kt
+++ b/app/src/main/java/com/OxGames/Pluvia/CrashHandler.kt
@@ -1,0 +1,91 @@
+package com.OxGames.Pluvia
+
+import android.content.Context
+import java.io.File
+import java.io.PrintWriter
+import java.io.StringWriter
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+class CrashHandler(
+    private val context: Context,
+    private val defaultHandler: Thread.UncaughtExceptionHandler?,
+) : Thread.UncaughtExceptionHandler {
+
+    companion object {
+        private const val LOG_CAT_COUNT = 150
+        private const val CRASH_FILE_HISTORY_COUNT = 1
+
+        fun initialize(context: Context) {
+            val defaultHandler = Thread.getDefaultUncaughtExceptionHandler()
+            val crashHandler = CrashHandler(context.applicationContext, defaultHandler)
+            Thread.setDefaultUncaughtExceptionHandler(crashHandler)
+        }
+    }
+
+    private val crashFileDir by lazy {
+        File(context.getExternalFilesDir(null), "crash_logs").apply {
+            if (!exists()) mkdirs()
+        }
+    }
+
+    private val recentLogcat: String
+        get() = try {
+            val process = Runtime.getRuntime().exec("logcat -d -t $LOG_CAT_COUNT --pid=${android.os.Process.myPid()}")
+            process.inputStream.bufferedReader().use { it.readText() }
+        } catch (e: Exception) {
+            "Failed to retrieve logcat: ${e.message}"
+        }
+
+    private val cleanupOldCrashFiles: () -> Unit = {
+        crashFileDir.listFiles()?.let { files ->
+            if (files.size > CRASH_FILE_HISTORY_COUNT) {
+                files.sortByDescending { it.lastModified() }
+                files.drop(CRASH_FILE_HISTORY_COUNT).forEach { it.delete() }
+            }
+        }
+    }
+
+    override fun uncaughtException(thread: Thread, throwable: Throwable) {
+        PrefManager.recentlyCrashed = true
+
+        saveCrashToFile(throwable)
+        defaultHandler?.uncaughtException(thread, throwable)
+    }
+
+    private fun saveCrashToFile(throwable: Throwable) {
+        try {
+            val stackTrace = StringWriter().apply {
+                val pw = PrintWriter(this)
+                throwable.printStackTrace(pw)
+            }.toString()
+
+            val timestamp = SimpleDateFormat("yyyy-MM-dd_HH-mm-ss", Locale.getDefault()).format(Date())
+
+            val crashReport = buildString {
+                appendLine("Timestamp: $timestamp")
+                appendLine("Exception: ${throwable.javaClass.name}")
+                appendLine("Message: ${throwable.message}")
+                appendLine()
+                appendLine("Stack Trace:")
+                appendLine(stackTrace)
+                appendLine()
+                appendLine("Device Information:")
+                appendLine("Model: ${android.os.Build.MODEL}")
+                appendLine("Android Version: ${android.os.Build.VERSION.RELEASE}")
+                appendLine("App Version: ${context.packageManager.getPackageInfo(context.packageName, 0).versionName}")
+                appendLine()
+                appendLine("Logcat:")
+                appendLine("----------------------------------------")
+                appendLine(recentLogcat)
+            }
+
+            File(crashFileDir, "pluvia_crash_$timestamp.txt").writeText(crashReport)
+
+            cleanupOldCrashFiles()
+        } catch (e: Exception) {
+            defaultHandler?.uncaughtException(Thread.currentThread(), throwable)
+        }
+    }
+}

--- a/app/src/main/java/com/OxGames/Pluvia/NotificationHelper.kt
+++ b/app/src/main/java/com/OxGames/Pluvia/NotificationHelper.kt
@@ -72,7 +72,7 @@ class NotificationHelper(private val context: Context) {
             context,
             0,
             stopIntent,
-            PendingIntent.FLAG_IMMUTABLE
+            PendingIntent.FLAG_IMMUTABLE,
         )
 
         return NotificationCompat.Builder(context, CHANNEL_ID)

--- a/app/src/main/java/com/OxGames/Pluvia/PluviaApp.kt
+++ b/app/src/main/java/com/OxGames/Pluvia/PluviaApp.kt
@@ -30,6 +30,9 @@ class PluviaApp : SplitCompatApplication() {
             Timber.plant(ReleaseTree())
         }
 
+        // Init out custom crash handler.
+        CrashHandler.initialize(this)
+
         // Init our datastore preferences.
         PrefManager.init(this)
     }

--- a/app/src/main/java/com/OxGames/Pluvia/PluviaApp.kt
+++ b/app/src/main/java/com/OxGames/Pluvia/PluviaApp.kt
@@ -30,7 +30,7 @@ class PluviaApp : SplitCompatApplication() {
             Timber.plant(ReleaseTree())
         }
 
-        // Init out custom crash handler.
+        // Init our custom crash handler.
         CrashHandler.initialize(this)
 
         // Init our datastore preferences.

--- a/app/src/main/java/com/OxGames/Pluvia/PrefManager.kt
+++ b/app/src/main/java/com/OxGames/Pluvia/PrefManager.kt
@@ -73,6 +73,14 @@ object PrefManager {
     //     }
     // }
 
+    /* Recent Crash Flag */
+    private val RECENTLY_CRASHED = booleanPreferencesKey("recently_crashed")
+    var recentlyCrashed: Boolean
+        get() = getPref(RECENTLY_CRASHED, false)
+        set(value) {
+            setPref(RECENTLY_CRASHED, value)
+        }
+
     /* Login Info */
     private val CELL_ID = intPreferencesKey("cell_id")
     var cellId: Int

--- a/app/src/main/java/com/OxGames/Pluvia/SteamService.kt
+++ b/app/src/main/java/com/OxGames/Pluvia/SteamService.kt
@@ -362,7 +362,7 @@ class SteamService : Service(), IChallengeUrlChanged {
                                             SplitInstallSessionStatus.INSTALLING,
                                             SplitInstallSessionStatus.DOWNLOADED,
                                             SplitInstallSessionStatus.DOWNLOADING,
-                                                -> {
+                                            -> {
                                                 if (!isActive) {
                                                     splitManager.cancelInstall(moduleInstallSessionId)
                                                     break
@@ -1724,7 +1724,6 @@ class SteamService : Service(), IChallengeUrlChanged {
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
-
         // Notification intents
         when (intent?.action) {
             NotificationHelper.ACTION_EXIT -> {

--- a/app/src/main/java/com/OxGames/Pluvia/enums/OS.kt
+++ b/app/src/main/java/com/OxGames/Pluvia/enums/OS.kt
@@ -1,7 +1,7 @@
 package com.OxGames.Pluvia.enums
 
-import timber.log.Timber
 import java.util.EnumSet
+import timber.log.Timber
 
 enum class OS {
     windows,

--- a/app/src/main/java/com/OxGames/Pluvia/enums/PathType.kt
+++ b/app/src/main/java/com/OxGames/Pluvia/enums/PathType.kt
@@ -3,8 +3,8 @@ package com.OxGames.Pluvia.enums
 import android.content.Context
 import com.OxGames.Pluvia.SteamService
 import com.winlator.xenvironment.ImageFs
-import timber.log.Timber
 import java.nio.file.Paths
+import timber.log.Timber
 
 enum class PathType {
     GameInstall,

--- a/app/src/main/java/com/OxGames/Pluvia/ui/PluviaMain.kt
+++ b/app/src/main/java/com/OxGames/Pluvia/ui/PluviaMain.kt
@@ -187,7 +187,7 @@ fun PluviaMain(
                                 title = "Recent Crash",
                                 message = "Sorry about that!\n" +
                                     "It would be nice to know about the recent issue you've had.\n" +
-                                    "You can export the most recent crash logs in the app's settings " +
+                                    "You can view and export the most recent crash log in the app's settings " +
                                     "and attach it as a Github issue in the project's repository.\n" +
                                     "Link to the Github repo is also in settings!",
                                 confirmBtnText = "OK",

--- a/app/src/main/java/com/OxGames/Pluvia/ui/component/dialog/state/MessageDialogState.kt
+++ b/app/src/main/java/com/OxGames/Pluvia/ui/component/dialog/state/MessageDialogState.kt
@@ -37,7 +37,7 @@ data class MessageDialogState(
                     title = savedMap["title"] as String?,
                     message = savedMap["message"] as String?,
                 )
-            }
+            },
         )
     }
 }

--- a/app/src/main/java/com/OxGames/Pluvia/ui/enums/DialogType.kt
+++ b/app/src/main/java/com/OxGames/Pluvia/ui/enums/DialogType.kt
@@ -1,6 +1,7 @@
 package com.OxGames.Pluvia.ui.enums
 
 enum class DialogType {
+    CRASH,
     SUPPORT,
     SYNC_CONFLICT,
     SYNC_FAIL,

--- a/app/src/main/java/com/OxGames/Pluvia/ui/model/UserLoginViewModel.kt
+++ b/app/src/main/java/com/OxGames/Pluvia/ui/model/UserLoginViewModel.kt
@@ -180,16 +180,17 @@ class UserLoginViewModel : ViewModel() {
 
     fun onRetry() {
         _loginState.update { currentState ->
-            currentState.copy(isSteamConnected = SteamService.isConnected)
             if (SteamService.isLoggedIn) {
                 // TODO: Can this be handled better?
                 // We're already logged in when 'onRetry' is called on 'init'. Show loading screen.
                 currentState.copy(
+                    isSteamConnected = SteamService.isConnected,
                     isLoggingIn = true,
                     loginResult = LoginResult.Success,
                 )
             } else {
                 currentState.copy(
+                    isSteamConnected = SteamService.isConnected,
                     isLoggingIn = SteamService.isLoggingIn,
                     attemptCount = currentState.attemptCount.plus(1),
                     isQrFailed = false,

--- a/app/src/main/java/com/OxGames/Pluvia/ui/screen/library/HomeLibraryAppScreen.kt
+++ b/app/src/main/java/com/OxGames/Pluvia/ui/screen/library/HomeLibraryAppScreen.kt
@@ -32,11 +32,11 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier

--- a/app/src/main/java/com/OxGames/Pluvia/ui/screen/settings/SettingsGroupDebug.kt
+++ b/app/src/main/java/com/OxGames/Pluvia/ui/screen/settings/SettingsGroupDebug.kt
@@ -13,8 +13,8 @@ import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Save
-import androidx.compose.material.icons.filled.Share
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -104,7 +104,7 @@ fun SettingsGroupDebug() {
                             navigationIcon = {
                                 IconButton(
                                     onClick = { showLogcatDialog = false },
-                                    content = { Icon(Icons.Default.Save, null) },
+                                    content = { Icon(Icons.Default.Close, null) },
                                 )
                             },
                             actions = {
@@ -112,7 +112,7 @@ fun SettingsGroupDebug() {
                                     onClick = {
                                         saveResultContract.launch(latestCrashFile!!.name)
                                     },
-                                    content = { Icon(Icons.Default.Share, null) },
+                                    content = { Icon(Icons.Default.Save, null) },
                                 )
                             },
                         )
@@ -145,15 +145,12 @@ fun SettingsGroupDebug() {
         SettingsMenuLink(
             title = { Text(text = "View Logcats") },
             subtitle = {
-                val subtitle by remember {
-                    val text = if (latestCrashFile != null) {
-                        "Shows the most recent crash log"
-                    } else {
-                        "No recent crash logs found"
-                    }
-                    mutableStateOf(text)
+                val text = if (latestCrashFile != null) {
+                    "Shows the most recent crash log"
+                } else {
+                    "No recent crash logs found"
                 }
-                Text(text = subtitle)
+                Text(text = text)
             },
             enabled = latestCrashFile != null,
             onClick = { showLogcatDialog = true },

--- a/app/src/main/java/com/OxGames/Pluvia/ui/screen/settings/SettingsGroupDebug.kt
+++ b/app/src/main/java/com/OxGames/Pluvia/ui/screen/settings/SettingsGroupDebug.kt
@@ -1,26 +1,165 @@
 package com.OxGames.Pluvia.ui.screen.settings
 
+import android.widget.Toast
 import androidx.activity.ComponentActivity
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Save
+import androidx.compose.material.icons.filled.Share
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
 import coil.annotation.ExperimentalCoilApi
 import coil.imageLoader
 import com.OxGames.Pluvia.BuildConfig
 import com.OxGames.Pluvia.PrefManager
 import com.alorma.compose.settings.ui.SettingsGroup
 import com.alorma.compose.settings.ui.SettingsMenuLink
+import java.io.File
 import kotlinx.coroutines.launch
 
-@OptIn(ExperimentalCoilApi::class)
+@OptIn(ExperimentalCoilApi::class, ExperimentalMaterial3Api::class)
 @Composable
 fun SettingsGroupDebug() {
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
 
-    if (BuildConfig.DEBUG) {
-        SettingsGroup(title = { Text(text = "Debug") }) {
+    /* Crash Log stuff */
+    var showLogcatDialog by remember { mutableStateOf(false) }
+    var latestCrashFile: File? by remember { mutableStateOf(null) }
+    LaunchedEffect(Unit) {
+        val crashDir = File(context.getExternalFilesDir(null), "crash_logs")
+        latestCrashFile = crashDir.listFiles()
+            ?.filter { it.name.startsWith("pluvia_crash_") }
+            ?.maxByOrNull { it.lastModified() }
+    }
+
+    /* Save crash log */
+    val saveResultContract = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.CreateDocument("text/plain"),
+    ) { resultUri ->
+        try {
+            resultUri?.let { uri ->
+                context.contentResolver.openOutputStream(uri)?.use { outputStream ->
+                    latestCrashFile?.inputStream()?.use { inputStream ->
+                        inputStream.copyTo(outputStream)
+                    }
+                }
+            }
+        } catch (e: Exception) {
+            Toast.makeText(context, "Failed to save logcat to destination", Toast.LENGTH_SHORT).show()
+        }
+    }
+
+    /* Show & Share crash log dialog */
+    if (showLogcatDialog && latestCrashFile != null) {
+        Dialog(
+            onDismissRequest = { showLogcatDialog = false },
+            properties = DialogProperties(
+                usePlatformDefaultWidth = false,
+                dismissOnClickOutside = false,
+            ),
+            content = {
+                val scrollState = rememberScrollState()
+
+                Scaffold(
+                    modifier = Modifier.fillMaxSize(),
+                    topBar = {
+                        CenterAlignedTopAppBar(
+                            title = {
+                                Text(
+                                    text = latestCrashFile?.name ?: "No Filename",
+                                    maxLines = 1,
+                                    overflow = TextOverflow.Ellipsis,
+                                )
+                            },
+                            navigationIcon = {
+                                IconButton(
+                                    onClick = { showLogcatDialog = false },
+                                    content = { Icon(Icons.Default.Save, null) },
+                                )
+                            },
+                            actions = {
+                                IconButton(
+                                    onClick = {
+                                        saveResultContract.launch(latestCrashFile!!.name)
+                                    },
+                                    content = { Icon(Icons.Default.Share, null) },
+                                )
+                            },
+                        )
+                    },
+                ) { paddingValues ->
+                    Column(
+                        modifier = Modifier
+                            .padding(paddingValues)
+                            .verticalScroll(scrollState)
+                            .fillMaxSize()
+                            .padding(top = WindowInsets.statusBars.asPaddingValues().calculateTopPadding()),
+                    ) {
+                        Text(
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .padding(horizontal = 6.dp),
+                            style = MaterialTheme.typography.bodyMedium.copy(
+                                fontFamily = FontFamily.Monospace,
+                            ),
+                            fontSize = 12.sp,
+                            text = latestCrashFile?.readText() ?: "No crash report found",
+                        )
+                    }
+                }
+            },
+        )
+    }
+
+    SettingsGroup(title = { Text(text = "Debug") }) {
+        SettingsMenuLink(
+            title = { Text(text = "View Logcats") },
+            subtitle = {
+                val subtitle by remember {
+                    val text = if (latestCrashFile != null) {
+                        "Shows the most recent crash log"
+                    } else {
+                        "No recent crash logs found"
+                    }
+                    mutableStateOf(text)
+                }
+                Text(text = subtitle)
+            },
+            enabled = latestCrashFile != null,
+            onClick = { showLogcatDialog = true },
+        )
+
+        if (BuildConfig.DEBUG) {
             SettingsMenuLink(
                 title = { Text(text = "Clear Preferences") },
                 onClick = {

--- a/app/src/main/java/com/OxGames/Pluvia/ui/screen/settings/SettingsGroupInfo.kt
+++ b/app/src/main/java/com/OxGames/Pluvia/ui/screen/settings/SettingsGroupInfo.kt
@@ -3,19 +3,17 @@ package com.OxGames.Pluvia.ui.screen.settings
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.MonetizationOn
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.setValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.unit.dp
@@ -85,7 +83,7 @@ fun SettingsGroupInfo() {
             onCheckedChange = {
                 askForTip = it
                 PrefManager.tipped = !askForTip
-            }
+            },
         )
 
         SettingsMenuLink(

--- a/app/src/main/java/com/OxGames/Pluvia/utils/FileUtils.kt
+++ b/app/src/main/java/com/OxGames/Pluvia/utils/FileUtils.kt
@@ -1,7 +1,6 @@
 package com.OxGames.Pluvia.utils
 
 import android.content.res.AssetManager
-import timber.log.Timber
 import java.io.BufferedReader
 import java.io.File
 import java.io.FileOutputStream
@@ -14,126 +13,125 @@ import java.util.stream.Stream
 import kotlin.io.path.exists
 import kotlin.io.path.isDirectory
 import kotlin.io.path.name
+import timber.log.Timber
 
-class FileUtils {
-    companion object {
+object FileUtils {
 
-        fun makeDir(dirName: String) {
-            val homeItemsDir = File(dirName)
-            homeItemsDir.mkdirs()
-        }
+    fun makeDir(dirName: String) {
+        val homeItemsDir = File(dirName)
+        homeItemsDir.mkdirs()
+    }
 
-        fun makeFile(fileName: String, errorTag: String? = "FileUtils", errorMsg: ((Exception) -> String)? = null) {
-            try {
-                val file = File(fileName)
-                if (!file.exists()) {
-                    file.createNewFile()
-                }
-            } catch (e: Exception) {
-                Timber.e("%s encountered an issue in makeFile()", errorTag)
-                Timber.e(errorMsg?.invoke(e) ?: "Error creating file: $e")
+    fun makeFile(fileName: String, errorTag: String? = "FileUtils", errorMsg: ((Exception) -> String)? = null) {
+        try {
+            val file = File(fileName)
+            if (!file.exists()) {
+                file.createNewFile()
             }
+        } catch (e: Exception) {
+            Timber.e("%s encountered an issue in makeFile()", errorTag)
+            Timber.e(errorMsg?.invoke(e) ?: "Error creating file: $e")
+        }
+    }
+
+    fun createPathIfNotExist(filepath: String) {
+        val file = File(filepath)
+        var dirs = filepath
+
+        // if the file path is not a directory and if we're not at the root directory then get the parent directory
+        if (!filepath.endsWith('/') && filepath.lastIndexOf('/') > 0) {
+            dirs = file.parent!!
         }
 
-        fun createPathIfNotExist(filepath: String) {
-            val file = File(filepath)
-            var dirs = filepath
+        makeDir(dirs)
+    }
 
-            // if the file path is not a directory and if we're not at the root directory then get the parent directory
-            if (!filepath.endsWith('/') && filepath.lastIndexOf('/') > 0) {
-                dirs = file.parent!!
-            }
+    fun readFileAsString(path: String, errorTag: String = "FileUtils", errorMsg: ((Exception) -> String)? = null): String? {
+        var fileData: String? = null
+        try {
+            val r = BufferedReader(FileReader(path))
+            val total = StringBuilder()
+            var line: String?
 
-            makeDir(dirs)
-        }
-
-        fun readFileAsString(path: String, errorTag: String = "FileUtils", errorMsg: ((Exception) -> String)? = null): String? {
-            var fileData: String? = null
-            try {
-                val r = BufferedReader(FileReader(path))
-                val total = StringBuilder()
-                var line: String?
-
-                while ((r.readLine().also { line = it }) != null) {
-                    total.append(line).append('\n')
-                }
-
-                fileData = total.toString()
-            } catch (e: Exception) {
-                Timber.e("%s encountered an issue in readFileAsString()", errorTag)
-                Timber.e(errorMsg?.invoke(e) ?: "Error reading file: $e")
+            while ((r.readLine().also { line = it }) != null) {
+                total.append(line).append('\n')
             }
 
-            return fileData
+            fileData = total.toString()
+        } catch (e: Exception) {
+            Timber.e("%s encountered an issue in readFileAsString()", errorTag)
+            Timber.e(errorMsg?.invoke(e) ?: "Error reading file: $e")
         }
 
-        fun writeStringToFile(data: String, path: String, errorTag: String? = "FileUtils", errorMsg: ((Exception) -> String)? = null) {
-            createPathIfNotExist(path)
+        return fileData
+    }
 
-            try {
-                val fOut = FileOutputStream(path)
-                val myOutWriter = OutputStreamWriter(fOut)
-                myOutWriter.append(data)
-                myOutWriter.close()
-                fOut.flush()
-                fOut.close()
-            } catch (e: Exception) {
-                Timber.e("%s encounted an issue in writeStringToFile()", errorTag)
-                Timber.e(errorMsg?.invoke(e) ?: "Error writing to file: $e")
+    fun writeStringToFile(data: String, path: String, errorTag: String? = "FileUtils", errorMsg: ((Exception) -> String)? = null) {
+        createPathIfNotExist(path)
+
+        try {
+            val fOut = FileOutputStream(path)
+            val myOutWriter = OutputStreamWriter(fOut)
+            myOutWriter.append(data)
+            myOutWriter.close()
+            fOut.flush()
+            fOut.close()
+        } catch (e: Exception) {
+            Timber.e("%s encounted an issue in writeStringToFile()", errorTag)
+            Timber.e(errorMsg?.invoke(e) ?: "Error writing to file: $e")
+        }
+    }
+
+    /**
+     * Traverse through a directory and perform an action on each file
+     *
+     * @param rootPath The start path
+     * @param maxDepth How deep to go in the directory tree, a value of -1 keeps going
+     * @param action The action to perform on each file
+     */
+    fun walkThroughPath(rootPath: Path, maxDepth: Int = 0, action: (Path) -> Unit) {
+        Files.list(rootPath).forEach {
+            action(it)
+            if (maxDepth != 0 && it.exists() && it.isDirectory()) {
+                walkThroughPath(
+                    rootPath = it,
+                    maxDepth = if (maxDepth > 0) maxDepth - 1 else maxDepth,
+                    action = action,
+                )
             }
         }
+    }
 
-        /**
-         * Traverse through a directory and perform an action on each file
-         *
-         * @param rootPath The start path
-         * @param maxDepth How deep to go in the directory tree, a value of -1 keeps going
-         * @param action The action to perform on each file
-         */
-        fun walkThroughPath(rootPath: Path, maxDepth: Int = 0, action: (Path) -> Unit) {
-            Files.list(rootPath).forEach {
-                action(it)
-                if (maxDepth != 0 && it.exists() && it.isDirectory()) {
-                    walkThroughPath(
-                        rootPath = it,
-                        maxDepth = if (maxDepth > 0) maxDepth - 1 else maxDepth,
-                        action = action,
-                    )
-                }
-            }
-        }
-
-        fun findFiles(rootPath: Path, pattern: String, includeDirectories: Boolean = false): Stream<Path> {
-            val patternParts = pattern.split("*").filter { it.isNotEmpty() }
-            Timber.i("$pattern -> $patternParts")
-            if (!Files.exists(rootPath)) return emptyList<Path>().stream()
-            return Files.list(rootPath).filter { path ->
-                if (path.isDirectory() && !includeDirectories) {
-                    false
-                } else {
-                    val fileName = path.name
-                    Timber.i("Checking $fileName for pattern $pattern")
-                    var startIndex = 0
-                    !patternParts.map {
-                        val index = fileName.indexOf(it, startIndex)
-                        if (index >= 0) {
-                            startIndex = index + it.length
-                        }
-                        index
-                    }.any { it < 0 }
-                }
-            }
-        }
-
-        fun assetExists(assetManager: AssetManager, assetPath: String): Boolean {
-            return try {
-                assetManager.open(assetPath).use {
-                    true
-                }
-            } catch (e: IOException) {
-                // Timber.e(e)
+    fun findFiles(rootPath: Path, pattern: String, includeDirectories: Boolean = false): Stream<Path> {
+        val patternParts = pattern.split("*").filter { it.isNotEmpty() }
+        Timber.i("$pattern -> $patternParts")
+        if (!Files.exists(rootPath)) return emptyList<Path>().stream()
+        return Files.list(rootPath).filter { path ->
+            if (path.isDirectory() && !includeDirectories) {
                 false
+            } else {
+                val fileName = path.name
+                Timber.i("Checking $fileName for pattern $pattern")
+                var startIndex = 0
+                !patternParts.map {
+                    val index = fileName.indexOf(it, startIndex)
+                    if (index >= 0) {
+                        startIndex = index + it.length
+                    }
+                    index
+                }.any { it < 0 }
             }
+        }
+    }
+
+    fun assetExists(assetManager: AssetManager, assetPath: String): Boolean {
+        return try {
+            assetManager.open(assetPath).use {
+                true
+            }
+        } catch (e: IOException) {
+            // Timber.e(e)
+            false
         }
     }
 }

--- a/app/src/main/java/com/winlator/PrefManager.kt
+++ b/app/src/main/java/com/winlator/PrefManager.kt
@@ -1,7 +1,6 @@
 package com.winlator
 
 import android.content.Context
-import android.util.Log
 import androidx.datastore.core.DataStore
 import androidx.datastore.core.handlers.ReplaceFileCorruptionHandler
 import androidx.datastore.preferences.core.Preferences


### PR DESCRIPTION
This PR adds a custom crash handler that runs locally on the device. If a crash is detected, it will save a report locally in the app's data folder. 

Upon next launch, it will show a dialog about the crash and not the tip dialog breifly explaining how they can help. 

If the user wants to share the report, they can navigate to the application's settings and "View Logcat" in the Debug section along the bottom. 

Here they can see what exactly is being collected, with the option to Save the log somewhere else as they please. 

Some infomation on what the file contains: 
- Only one copy of a crash report. Previous ones will be removed automatically. 
- Timestamp of when the crash occurred
- The type of exception thrown
- The exception message
- The stack trace of the crash
- The model of the device. 
- The android version
- The application version
- Followed by the last 150 lines of the logcat. Filtered by the app's pid to cut down on usless log lines.

Note: If the application currently crashes before the library screen shows. This dialog won't be shown. The file can still be accessed `<user storage>/Android/data/com.OxGames.Pluvia/files/crash_logs` for manual intervention. 

Also some code formatting and other minor code tweaks. 