### PR TITLE
Show login errors via snackbar instead of crashing.

### DIFF
--- a/app/src/main/java/com/OxGames/Pluvia/events/SteamEvent.kt
+++ b/app/src/main/java/com/OxGames/Pluvia/events/SteamEvent.kt
@@ -6,7 +6,7 @@ import com.OxGames.Pluvia.enums.LoginResult
 sealed interface SteamEvent<T> : Event<T> {
     data class Connected(val isAutoLoggingIn: Boolean) : SteamEvent<Unit>
     data class LoggedOut(val username: String?) : SteamEvent<Unit>
-    data class LogonEnded(val username: String?, val loginResult: LoginResult) : SteamEvent<Unit>
+    data class LogonEnded(val username: String?, val loginResult: LoginResult, val failMessage: String? = null) : SteamEvent<Unit>
     data class LogonStarted(val username: String?) : SteamEvent<Unit>
     data class PersonaStateReceived(val persona: SteamFriend?) : SteamEvent<Unit>
     data class QrAuthEnded(val success: Boolean) : SteamEvent<Unit>

--- a/app/src/main/java/com/OxGames/Pluvia/ui/data/LibraryState.kt
+++ b/app/src/main/java/com/OxGames/Pluvia/ui/data/LibraryState.kt
@@ -7,4 +7,6 @@ data class LibraryState(
     val searchAlphabetic: Boolean = false,
     val searchInstalled: Boolean = false,
     val appInfoList: List<AppInfo> = listOf(),
+
+    val snackbarMessage: String? = null,
 )

--- a/app/src/main/java/com/OxGames/Pluvia/ui/data/UserLoginState.kt
+++ b/app/src/main/java/com/OxGames/Pluvia/ui/data/UserLoginState.kt
@@ -22,4 +22,6 @@ data class UserLoginState(
 
     val qrCode: String? = null,
     val isQrFailed: Boolean = false,
+
+    val snackbarMessage: String? = null
 )

--- a/app/src/main/java/com/OxGames/Pluvia/ui/model/LibraryViewModel.kt
+++ b/app/src/main/java/com/OxGames/Pluvia/ui/model/LibraryViewModel.kt
@@ -39,7 +39,7 @@ class LibraryViewModel : ViewModel() {
             when (filter) {
                 FabFilter.SEARCH -> {
                     Timber.w("Search not implemented!")
-                    currentValue.copy()
+                    currentValue.copy(snackbarMessage = "Search not implemented yet!")
                 }
 
                 FabFilter.INSTALLED -> currentValue.copy(searchInstalled = !currentValue.searchInstalled)
@@ -48,6 +48,10 @@ class LibraryViewModel : ViewModel() {
         }
 
         getAppList()
+    }
+
+    fun clearSnackbar() {
+        _state.update { it.copy(snackbarMessage = null) }
     }
 
     private fun getAppList() {

--- a/app/src/main/java/com/OxGames/Pluvia/ui/model/UserLoginViewModel.kt
+++ b/app/src/main/java/com/OxGames/Pluvia/ui/model/UserLoginViewModel.kt
@@ -110,16 +110,19 @@ class UserLoginViewModel : ViewModel() {
     }
 
     private val onLogonEnded: (SteamEvent.LogonEnded) -> Unit = {
-        Timber.i("Received login result: ${it.loginResult}")
+        Timber.i("Received login result: ${it.loginResult} / ${it.failMessage}")
+
         _loginState.update { currentState ->
             currentState.copy(
                 isLoggingIn = false,
                 loginResult = it.loginResult,
+                snackbarMessage = it.failMessage,
             )
         }
-        if (it.loginResult != LoginResult.Success) {
-            SteamService.startLoginWithQr()
-        }
+
+        // if (it.loginResult != LoginResult.Success) {
+        //     SteamService.startLoginWithQr()
+        // }
     }
 
     private val onBackPressed: (AndroidEvent.BackPressed) -> Unit = {
@@ -235,5 +238,9 @@ class UserLoginViewModel : ViewModel() {
         _loginState.update { currentState ->
             currentState.copy(twoFactorCode = twoFactorCode)
         }
+    }
+
+    fun clearSnackbar() {
+        _loginState.update { it.copy(snackbarMessage = null) }
     }
 }

--- a/app/src/main/java/com/OxGames/Pluvia/ui/screen/library/HomeLibraryScreen.kt
+++ b/app/src/main/java/com/OxGames/Pluvia/ui/screen/library/HomeLibraryScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.material3.adaptive.layout.ListDetailPaneScaffoldRole
 import androidx.compose.material3.adaptive.navigation.BackNavigationBehavior
 import androidx.compose.material3.adaptive.navigation.rememberListDetailPaneScaffoldNavigator
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -59,12 +60,22 @@ fun HomeLibraryScreen(
     onSettings: () -> Unit,
     onLogout: () -> Unit,
 ) {
+    val snackbarHost = remember { SnackbarHostState() }
+
     val vmState by viewModel.state.collectAsStateWithLifecycle()
     val fabState = rememberFloatingActionMenuState()
+
+    LaunchedEffect(vmState.snackbarMessage) {
+        vmState.snackbarMessage?.let {
+            snackbarHost.showSnackbar(it)
+            viewModel.clearSnackbar()
+        }
+    }
 
     LibraryScreenContent(
         vmState = vmState,
         fabState = fabState,
+        snackbarHost = snackbarHost,
         onFabFilter = viewModel::onFabFilter,
         onClickPlay = onClickPlay,
         onSettings = onSettings,
@@ -77,12 +88,12 @@ fun HomeLibraryScreen(
 private fun LibraryScreenContent(
     vmState: LibraryState,
     fabState: FloatingActionMenuState,
+    snackbarHost: SnackbarHostState,
     onFabFilter: (FabFilter) -> Unit,
     onClickPlay: (Int, Boolean) -> Unit,
     onSettings: () -> Unit,
     onLogout: () -> Unit,
 ) {
-    val snackbarHost = remember { SnackbarHostState() }
     val navigator = rememberListDetailPaneScaffoldNavigator<Int>()
 
     // Pretty much the same as 'NavigableListDetailPaneScaffold'
@@ -223,6 +234,7 @@ private fun Preview_LibraryScreenContent() {
                 appInfoList = List(15) { fakeAppInfo(it).copy(appId = it) },
             ),
             fabState = rememberFloatingActionMenuState(FloatingActionMenuValue.Open),
+            snackbarHost = SnackbarHostState(),
             onFabFilter = {},
             onClickPlay = { _, _ -> },
             onSettings = {},

--- a/app/src/main/java/com/OxGames/Pluvia/ui/screen/login/UserLoginScreen.kt
+++ b/app/src/main/java/com/OxGames/Pluvia/ui/screen/login/UserLoginScreen.kt
@@ -66,7 +66,6 @@ import com.OxGames.Pluvia.ui.component.LoadingScreen
 import com.OxGames.Pluvia.ui.data.UserLoginState
 import com.OxGames.Pluvia.ui.model.UserLoginViewModel
 import com.OxGames.Pluvia.ui.theme.PluviaTheme
-import kotlinx.coroutines.flow.collectLatest
 
 @Composable
 fun UserLoginScreen(


### PR DESCRIPTION
Pecking at some low hanging crashes that are relatively simple to fix up. 

The focus of this PR is to stop the login process (Credential and QR) to report any messages if something were to happen, such as `EResult` messages. Anything other than a `AuthenticationException` will just show the canonicalName of the reason what is crashing.

This is to keep the app from crashing, but handle any exceptions or EResults more gracefully. 

Note: Trying to press `login` again results in a `CancellationException` message. This is being looked into for another PR. 

Also budging in a visual indication that search is not implemented. 