### PR TITLE
String resource fix

### DIFF
--- a/app/src/main/java/com/OxGames/Pluvia/ui/component/dialog/ContainerConfigDialog.kt
+++ b/app/src/main/java/com/OxGames/Pluvia/ui/component/dialog/ContainerConfigDialog.kt
@@ -653,7 +653,7 @@ private fun winComponentsItemTitle(string: String): String {
         "directx" -> R.string.directx
         "vcrun2010" -> R.string.vcrun2010
         "wmdecoder" -> R.string.wmdecoder
-        else -> throw IllegalArgumentException("No string res found for Win Components title")
+        else -> throw IllegalArgumentException("No string res found for Win Components title: $string")
     }
     return stringResource(resource)
 }

--- a/app/src/main/java/com/OxGames/Pluvia/ui/component/dialog/ContainerConfigDialog.kt
+++ b/app/src/main/java/com/OxGames/Pluvia/ui/component/dialog/ContainerConfigDialog.kt
@@ -44,6 +44,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringArrayResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextOverflow
@@ -465,7 +466,7 @@ fun ContainerConfigDialog(
                         SettingsGroup(title = { Text(text = "Win Components") }) {
                             for (wincomponent in KeyValueSet(config.wincomponents)) {
                                 val compId = wincomponent[0]
-                                val compName = StringUtils.getString(context, compId)
+                                val compName = winComponentsItemTitle(compId)
                                 val compValue = wincomponent[1].toInt()
                                 SettingsListDropdown(
                                     title = { Text(compName) },
@@ -636,4 +637,23 @@ fun ContainerConfigDialog(
             },
         )
     }
+}
+
+/**
+ * Gets the component title for Win Components settings group.
+ */
+@Composable
+private fun winComponentsItemTitle(string: String): String {
+    val resource = when (string) {
+        "direct3d" -> R.string.direct3d
+        "directsound" -> R.string.directsound
+        "directmusic" -> R.string.directmusic
+        "directplay" -> R.string.directplay
+        "directshow" -> R.string.directshow
+        "directx" -> R.string.directx
+        "vcrun2010" -> R.string.vcrun2010
+        "wmdecoder" -> R.string.wmdecoder
+        else -> throw IllegalArgumentException("No string res found for Win Components title")
+    }
+    return stringResource(resource)
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -38,6 +38,7 @@
     <string name="performance">Performance</string>
     <string name="title_ubuntufs">Ubuntu FS</string>
 
+    <!-- Winlator: Win Components -->
     <string name="direct3d">Direct3D</string>
     <string name="directsound">DirectSound</string>
     <string name="directmusic">DirectMusic</string>


### PR DESCRIPTION
Using `context.getResources().getIdentifier()` isnt recommened with the following warning: 

```
Use of this function is discouraged because resource reflection makes it harder to perform build optimizations and compile-time verification of code. It is much more efficient to retrieve resources by identifier (e. g. R. foo. bar) than by name (e. g. getIdentifier("bar", "foo", null))
```

And testing the app in a release build causes it to crash trying to get the Win Component item titles. 

This method isn't perfect, but to avoid using reflection; which is always an unknown, a private composable function was created to map out the strings and returns the correct string resource if one is found... Not that many items to map out. Otherwise it'll throw if a component was added without the accompanying string resource. 