### PR TITLE
Miscellaneous fixes

### DIFF
--- a/app/src/main/java/com/OxGames/Pluvia/events/SteamEvent.kt
+++ b/app/src/main/java/com/OxGames/Pluvia/events/SteamEvent.kt
@@ -6,12 +6,13 @@ import com.OxGames.Pluvia.enums.LoginResult
 sealed interface SteamEvent<T> : Event<T> {
     data class Connected(val isAutoLoggingIn: Boolean) : SteamEvent<Unit>
     data class LoggedOut(val username: String?) : SteamEvent<Unit>
-    data class LogonEnded(val username: String?, val loginResult: LoginResult) : SteamEvent<Unit>
+    data class LogonEnded(val username: String?, val loginResult: LoginResult, val message: String? = null) : SteamEvent<Unit>
     data class LogonStarted(val username: String?) : SteamEvent<Unit>
     data class PersonaStateReceived(val persona: SteamFriend?) : SteamEvent<Unit>
-    data class QrAuthEnded(val success: Boolean) : SteamEvent<Unit>
+    data class QrAuthEnded(val success: Boolean, val message: String? = null) : SteamEvent<Unit>
     data class QrChallengeReceived(val challengeUrl: String) : SteamEvent<Unit>
     data object AppInfoReceived : SteamEvent<Unit>
     data object ForceCloseApp : SteamEvent<Unit>
     data object Disconnected : SteamEvent<Unit>
+    data object RemotelyDisconnected : SteamEvent<Unit>
 }

--- a/app/src/main/java/com/OxGames/Pluvia/service/SteamService.kt
+++ b/app/src/main/java/com/OxGames/Pluvia/service/SteamService.kt
@@ -188,7 +188,7 @@ class SteamService : Service(), IChallengeUrlChanged {
          * Default timeout to use when reading the response body
          */
 
-        private val PROTOCOL_TYPES = EnumSet.of(ProtocolTypes.TCP, ProtocolTypes.UDP)
+        private val PROTOCOL_TYPES = EnumSet.of(ProtocolTypes.WEB_SOCKET)
 
         private var instance: SteamService? = null
 

--- a/app/src/main/java/com/OxGames/Pluvia/service/SteamService.kt
+++ b/app/src/main/java/com/OxGames/Pluvia/service/SteamService.kt
@@ -65,6 +65,7 @@ import `in`.dragonbra.javasteam.protobufs.steamclient.SteammessagesClientObjects
 import `in`.dragonbra.javasteam.rpc.service.Chat
 import `in`.dragonbra.javasteam.steam.authentication.AuthPollResult
 import `in`.dragonbra.javasteam.steam.authentication.AuthSessionDetails
+import `in`.dragonbra.javasteam.steam.authentication.AuthenticationException
 import `in`.dragonbra.javasteam.steam.authentication.IAuthenticator
 import `in`.dragonbra.javasteam.steam.authentication.IChallengeUrlChanged
 import `in`.dragonbra.javasteam.steam.authentication.QrAuthSession
@@ -109,6 +110,7 @@ import java.nio.file.Files
 import java.nio.file.Paths
 import java.util.Date
 import java.util.EnumSet
+import java.util.concurrent.CancellationException
 import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Inject
 import kotlin.io.path.pathString
@@ -827,24 +829,28 @@ class SteamService : Service(), IChallengeUrlChanged {
             shouldRememberPassword: Boolean,
             authenticator: IAuthenticator,
         ) = withContext(Dispatchers.IO) {
-            Timber.i("Logging in via credentials.")
+            try {
+                Timber.i("Logging in via credentials.")
 
-            instance!!.steamClient?.let { steamClient ->
-                val authDetails = AuthSessionDetails().apply {
-                    this.username = username.trim()
-                    this.password = password.trim()
-                    this.persistentSession = shouldRememberPassword
-                    this.authenticator = authenticator
-                    this.deviceFriendlyName = SteamUtils.getMachineName(instance!!)
-                }
+                instance!!.steamClient?.let { steamClient ->
+                    val authDetails = AuthSessionDetails().apply {
+                        this.username = username.trim()
+                        this.password = password.trim()
+                        this.persistentSession = shouldRememberPassword
+                        this.authenticator = authenticator
+                        this.deviceFriendlyName = SteamUtils.getMachineName(instance!!)
+                    }
 
-                val authSession = steamClient.authentication.beginAuthSessionViaCredentials(authDetails, this).await()
+                    PluviaApp.events.emit(SteamEvent.LogonStarted(username))
 
-                PluviaApp.events.emit(SteamEvent.LogonStarted(username))
+                    val authSession = steamClient.authentication.beginAuthSessionViaCredentials(authDetails).await()
 
-                val pollResult = authSession.pollingWaitForResult().await()
+                    val pollResult = authSession.pollingWaitForResult().await()
 
-                if (pollResult.accountName.isNotEmpty() && pollResult.refreshToken.isNotEmpty()) {
+                    if (pollResult.accountName.isEmpty() && pollResult.refreshToken.isEmpty()) {
+                        throw Exception("No account name or refresh token received.")
+                    }
+
                     login(
                         clientId = authSession.clientID,
                         username = pollResult.accountName,
@@ -852,81 +858,93 @@ class SteamService : Service(), IChallengeUrlChanged {
                         refreshToken = pollResult.refreshToken,
                         shouldRememberPassword = shouldRememberPassword,
                     )
+                } ?: run {
+                    Timber.e("Could not logon: Failed to connect to Steam")
+                    PluviaApp.events.emit(SteamEvent.LogonEnded(username, LoginResult.Failed, "No connection to Steam"))
                 }
-
-                return@withContext
+            } catch (e: Exception) {
+                Timber.e(e, "Login failed")
+                val message = when (e) {
+                    is CancellationException -> "Unknown cancellation"
+                    is AuthenticationException -> e.result?.name ?: e.message
+                    else -> e.message ?: e.javaClass.name
+                }
+                PluviaApp.events.emit(SteamEvent.LogonEnded(username, LoginResult.Failed, message))
             }
-
-            Timber.e("Could not logon: Failed to connect to Steam")
-            PluviaApp.events.emit(SteamEvent.LogonEnded(username, LoginResult.Failed))
         }
 
         suspend fun startLoginWithQr() = withContext(Dispatchers.IO) {
-            Timber.i("Logging in via QR.")
+            try {
+                Timber.i("Logging in via QR.")
 
-            val steamClient = instance!!.steamClient
+                instance!!.steamClient?.let { steamClient ->
+                    isWaitingForQRAuth = true
 
-            if (steamClient != null) {
-                isWaitingForQRAuth = true
-
-                val authDetails = AuthSessionDetails().apply {
-                    deviceFriendlyName = SteamUtils.getMachineName(instance!!)
-                }
-
-                val authSession = steamClient.authentication.beginAuthSessionViaQR(authDetails, this).await()
-
-                // Steam will periodically refresh the challenge url, this callback allows you to draw a new qr code.
-                authSession.challengeUrlChanged = instance
-
-                PluviaApp.events.emit(SteamEvent.QrChallengeReceived(authSession.challengeUrl))
-
-                Timber.d("PollingInterval: ${authSession.pollingInterval.toLong()}")
-
-                var authPollResult: AuthPollResult? = null
-
-                while (isWaitingForQRAuth && authPollResult == null) {
-                    try {
-                        authPollResult = authSession.pollAuthSessionStatus(this).await()
-                    } catch (e: Exception) {
-                        Timber.e("Poll auth session status error: $e")
-
-                        break
+                    val authDetails = AuthSessionDetails().apply {
+                        deviceFriendlyName = SteamUtils.getMachineName(instance!!)
                     }
 
-                    // Sensitive info, only print in DEBUG build.
-                    if (BuildConfig.DEBUG && authPollResult != null) {
-                        Timber.d(
-                            "AccessToken: %s\nAccountName: %s\nRefreshToken: %s\nNewGuardData: %s",
-                            authPollResult.accessToken,
-                            authPollResult.accountName,
-                            authPollResult.refreshToken,
-                            authPollResult.newGuardData ?: "No new guard data",
-                        )
+                    val authSession = steamClient.authentication.beginAuthSessionViaQR(authDetails).await()
+
+                    // Steam will periodically refresh the challenge url, this callback allows you to draw a new qr code.
+                    authSession.challengeUrlChanged = instance
+
+                    PluviaApp.events.emit(SteamEvent.QrChallengeReceived(authSession.challengeUrl))
+
+                    Timber.d("PollingInterval: ${authSession.pollingInterval.toLong()}")
+
+                    var authPollResult: AuthPollResult? = null
+
+                    while (isWaitingForQRAuth && authPollResult == null) {
+                        try {
+                            authPollResult = authSession.pollAuthSessionStatus().await()
+                        } catch (e: Exception) {
+                            Timber.e(e, "Poll auth session status error")
+                            throw e
+                        }
+
+                        // Sensitive info, only print in DEBUG build.
+                        if (BuildConfig.DEBUG && authPollResult != null) {
+                            Timber.d(
+                                "AccessToken: %s\nAccountName: %s\nRefreshToken: %s\nNewGuardData: %s",
+                                authPollResult.accessToken,
+                                authPollResult.accountName,
+                                authPollResult.refreshToken,
+                                authPollResult.newGuardData ?: "No new guard data",
+                            )
+                        }
+
+                        delay(authSession.pollingInterval.toLong())
                     }
 
-                    delay(authSession.pollingInterval.toLong())
+                    isWaitingForQRAuth = false
+
+                    PluviaApp.events.emit(SteamEvent.QrAuthEnded(authPollResult != null))
+
+                    // there is a chance qr got cancelled and there is no authPollResult
+                    if (authPollResult == null) {
+                        Timber.e("Got no auth poll result")
+                        throw Exception("Got no auth poll result")
+                    }
+
+                    login(
+                        clientId = authSession.clientID,
+                        username = authPollResult.accountName,
+                        accessToken = authPollResult.accessToken,
+                        refreshToken = authPollResult.refreshToken,
+                    )
+                } ?: run {
+                    Timber.e("Could not start QR logon: Failed to connect to Steam")
+                    PluviaApp.events.emit(SteamEvent.QrAuthEnded(false, "No connection to Steam"))
                 }
-
-                isWaitingForQRAuth = false
-
-                PluviaApp.events.emit(SteamEvent.QrAuthEnded(authPollResult != null))
-
-                // there is a chance qr got cancelled and there is no authPollResult
-                if (authPollResult == null) {
-                    Timber.w("Got no auth poll result")
-                    return@withContext
+            } catch (e: Exception) {
+                Timber.e(e, "QR failed")
+                val message = when (e) {
+                    is CancellationException -> "QR Session timed out"
+                    is AuthenticationException -> e.result?.name ?: e.message
+                    else -> e.message ?: e.javaClass.name
                 }
-
-                login(
-                    clientId = authSession.clientID,
-                    username = authPollResult.accountName,
-                    accessToken = authPollResult.accessToken,
-                    refreshToken = authPollResult.refreshToken,
-                )
-            } else {
-                Timber.e("Could not start QR logon: Failed to connect to Steam")
-
-                PluviaApp.events.emit(SteamEvent.QrAuthEnded(false))
+                PluviaApp.events.emit(SteamEvent.QrAuthEnded(false, message))
             }
         }
 
@@ -1216,6 +1234,7 @@ class SteamService : Service(), IChallengeUrlChanged {
             Timber.w("Attempting to reconnect (retry $retryAttempt)")
 
             // isLoggingOut = false
+            PluviaApp.events.emit(SteamEvent.RemotelyDisconnected)
 
             connectToSteam()
         } else {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -80,6 +80,7 @@ junit = { group = "junit", name = "junit", version.ref = "junit" }
 commons-io = { module = "commons-io:commons-io", version = "2.17.0" } # https://mvnrepository.com/artifact/commons-io/commons-io
 commons-lang3 = { module = "org.apache.commons:commons-lang3", version = "3.17.0" } # https://mvnrepository.com/artifact/org.apache.commons/commons-lang3
 commons-validator = { module = "commons-validator:commons-validator", version = "1.9.0" } # https://mvnrepository.com/artifact/commons-validator/commons-validator
+ktor-engine = { module = "io.ktor:ktor-client-cio", version = "3.0.3" } # https://mvnrepository.com/artifact/io.ktor/ktor-client-cio
 xz = { module = "org.tukaani:xz", version = "1.10" } # https://mvnrepository.com/artifact/org.tukaani/xz
 
 [plugins]
@@ -129,6 +130,7 @@ steamkit-dev = [
     "commons-lang3",
     "commons-validator",
     "xz",
+    "ktor-engine"
 ]
 google = [
     "feature-delivery",


### PR DESCRIPTION
After many weeks (not really only 2 or 3 weeks) of painstakingly combing through Pluvia and JavaSteam wondering why we crash when a failed login happens, most reports due to invalid credentials. I finally found the solution (always the simplist fix of course 😆)

Long story short, the issue is with the TCP socket protocol in JavaSteam!
When a login failure happens, the connection to the CM server should of indicate it no longer wants to receieve messages, but that never happens. 

Even if catching the exception was handled earlier in code commits, pressing login/qr again would just sit there and do nothing (ui wise)

TCP/UDP support through JavaSteam is on hold because more CM's are using websockets, so any bug fixes to those connection handlers aren't on the roadmap to fix. By default WebSockets is a default protocol in JavaSteam since a botched weekend update broke TLS support for TCP/UDP connections last october from valve. This broke most 3rd party clients and the official iPhone steam app during that time.

With WebSockets we're able to detect when a CM no longer wishes to listen or transmit data, which then will cause a disconnection in order to be handled. 

### Fixes
- Use Web Socket as the default protocol
- Handle login failues gracefully
- Expose login error messages to be displayed via snackbar on the login screen.
- Add `RemotelyDisconnected` event, this can be used elsewhere in the app. 

