### PR TITLE
Feat/UI improvements

### DIFF
--- a/app/src/main/java/com/OxGames/Pluvia/ui/screen/library/HomeLibraryAppScreen.kt
+++ b/app/src/main/java/com/OxGames/Pluvia/ui/screen/library/HomeLibraryAppScreen.kt
@@ -3,7 +3,6 @@ package com.OxGames.Pluvia.ui.screen.library
 import android.content.Intent
 import android.content.res.Configuration
 import android.net.Uri
-import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.Crossfade
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -74,7 +73,6 @@ import com.winlator.xenvironment.ImageFsInstaller
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import timber.log.Timber
 
 // https://partner.steamgames.com/doc/store/assets/libraryassets#4
 

--- a/app/src/main/java/com/OxGames/Pluvia/ui/screen/library/HomeLibraryAppScreen.kt
+++ b/app/src/main/java/com/OxGames/Pluvia/ui/screen/library/HomeLibraryAppScreen.kt
@@ -3,6 +3,8 @@ package com.OxGames.Pluvia.ui.screen.library
 import android.content.Intent
 import android.content.res.Configuration
 import android.net.Uri
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.Crossfade
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -461,24 +463,30 @@ private fun AppScreenContent(
                 )
             }
 
-            if (isDownloading) {
-                Column(
-                    modifier = Modifier
-                        .align(Alignment.CenterVertically)
-                        .weight(1f)
-                        .padding(4.dp),
-                ) {
-                    Text(
-                        modifier = Modifier.align(Alignment.End),
-                        text = "${(downloadProgress * 100f).toInt()}%",
-                    )
-                    LinearProgressIndicator(
-                        modifier = Modifier.fillMaxWidth(),
-                        progress = { downloadProgress },
+            Crossfade(targetState = isDownloading) { downloading ->
+                if (downloading) {
+                    Column(
+                        modifier = Modifier
+                            .align(Alignment.CenterVertically)
+                            .weight(1f)
+                            .padding(4.dp),
+                    ) {
+                        Text(
+                            modifier = Modifier.align(Alignment.End),
+                            text = "${(downloadProgress * 100f).toInt()}%",
+                        )
+                        LinearProgressIndicator(
+                            modifier = Modifier.fillMaxWidth(),
+                            progress = { downloadProgress },
+                        )
+                    }
+                } else {
+                    Spacer(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .weight(1f),
                     )
                 }
-            } else {
-                Spacer(Modifier.weight(1f))
             }
 
             Box {

--- a/app/src/main/java/com/OxGames/Pluvia/ui/screen/library/HomeLibraryAppScreen.kt
+++ b/app/src/main/java/com/OxGames/Pluvia/ui/screen/library/HomeLibraryAppScreen.kt
@@ -72,6 +72,7 @@ import com.winlator.xenvironment.ImageFsInstaller
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import timber.log.Timber
 
 // https://partner.steamgames.com/doc/store/assets/libraryassets#4
 
@@ -83,11 +84,16 @@ fun AppScreen(
     onBack: () -> Unit,
 ) {
     val context = LocalContext.current
-    var downloadInfo by remember {
+    var downloadInfo by remember(appId) {
         mutableStateOf(SteamService.getAppDownloadInfo(appId))
     }
-    var downloadProgress by remember { mutableFloatStateOf(downloadInfo?.getProgress() ?: 0f) }
-    var isInstalled by remember { mutableStateOf(SteamService.isAppInstalled(appId)) }
+    var downloadProgress by remember(appId) {
+        mutableFloatStateOf(downloadInfo?.getProgress() ?: 0f)
+    }
+    var isInstalled by remember(appId) {
+        mutableStateOf(SteamService.isAppInstalled(appId))
+    }
+
     val isDownloading: () -> Boolean = { downloadInfo != null && downloadProgress < 1f }
 
     var loadingDialogVisible by rememberSaveable { mutableStateOf(false) }
@@ -431,6 +437,7 @@ private fun AppScreenContent(
                 previewPlaceholder = painterResource(R.drawable.testliblogo),
             )
         }
+
 
         // Controls Row
         Row(

--- a/app/src/main/java/com/OxGames/Pluvia/ui/screen/library/HomeLibraryScreen.kt
+++ b/app/src/main/java/com/OxGames/Pluvia/ui/screen/library/HomeLibraryScreen.kt
@@ -149,13 +149,19 @@ private fun LibraryScreenContent(
                             FloatingActionMenuItem(
                                 labelText = "Installed",
                                 isSelected = state.appInfoSortType == FabFilter.INSTALLED,
-                                onClick = { onFabFilter(FabFilter.INSTALLED) },
+                                onClick = {
+                                    onFabFilter(FabFilter.INSTALLED)
+                                    fabState.close()
+                                },
                                 content = { Icon(Icons.Filled.InstallMobile, "Installed") },
                             )
                             FloatingActionMenuItem(
                                 labelText = "Alphabetic",
                                 isSelected = state.appInfoSortType == FabFilter.ALPHABETIC,
-                                onClick = { onFabFilter(FabFilter.ALPHABETIC) },
+                                onClick = {
+                                    onFabFilter(FabFilter.ALPHABETIC)
+                                    fabState.close()
+                                },
                                 content = { Icon(Icons.Filled.SortByAlpha, "Alphabetic") },
                             )
                         }


### PR DESCRIPTION
### A UI related fix and some small general improvements

#### **fix**: Correct display of install/run button and download progress for apps
- Made `isInstalled` reactive to `appId` to ensure the correct state is shown when switching between apps.
- Updated `downloadInfo` and `downloadProgress` to be reactive to `appId` changes, fixing the issue where the download progress bar persisted across different apps.

#### **ui**: Add smooth transitions for download state and ensure UI consistency
- Replaced conditional `if`-statements with `Crossfade` for smooth transitions between downloading and non-downloading states.
- Ensured `Spacer` is displayed correctly when not downloading by applying appropriate layout constraints.

#### **ui**: Automatically dismiss FAB menu after filter selection
- Updated `FloatingActionMenuItem` click handlers to close the FAB menu (`fabState.close()`) after a filter is selected.
- Ensured smoother and more intuitive user interaction by automatically hiding the menu post-selection.