### PR TITLE
Fix crash for Top padding must be non-negative

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -42,8 +42,8 @@ android {
         minSdk = 29
         targetSdk = 34
 
-        versionCode = 4
-        versionName = "1.3.0"
+        versionCode = 5
+        versionName = "1.3.1"
 
         buildConfigField("boolean", "GOLD", "false")
         val iconValue = "@mipmap/ic_launcher"

--- a/app/src/main/java/com/OxGames/Pluvia/ui/screen/library/components/LibraryListPane.kt
+++ b/app/src/main/java/com/OxGames/Pluvia/ui/screen/library/components/LibraryListPane.kt
@@ -108,7 +108,8 @@ internal fun LibraryListPane(
                 list = state.appInfoList,
                 listState = listState,
                 contentPaddingValues = PaddingValues(
-                    top = paddingValues.calculateTopPadding().minus(statusBarPadding),
+                    // TODO this fixes a `Top padding must be non-negative` crash on P9PXL, but I don't fully know why.
+                    top = maxOf(0.dp, paddingValues.calculateTopPadding().minus(statusBarPadding)),
                     bottom = 72.dp,
                 ),
                 onItemClick = onNavigate,


### PR DESCRIPTION
🤷 Fixes a crash for a negative padding number. This layout hierarchy may need to be revised as it now breaks list items scrolling underneath the search bar. 

Crash discovered on my Pixel 9 Pro XL. 