### PR TITLE
Fix "Exit" not terminating service when app is not in focus

### DIFF
--- a/app/src/main/java/com/OxGames/Pluvia/MainActivity.kt
+++ b/app/src/main/java/com/OxGames/Pluvia/MainActivity.kt
@@ -67,7 +67,6 @@ class MainActivity : ComponentActivity() {
     }
 
     private val onEndProcess: (AndroidEvent.EndProcess) -> Unit = {
-        SteamService.stop()
         finishAndRemoveTask()
     }
 

--- a/app/src/main/java/com/OxGames/Pluvia/service/NotificationHelper.kt
+++ b/app/src/main/java/com/OxGames/Pluvia/service/NotificationHelper.kt
@@ -71,7 +71,7 @@ class NotificationHelper(private val context: Context) {
         val stopIntent = Intent(context, SteamService::class.java).apply {
             action = ACTION_EXIT
         }
-        val stopPendingIntent = PendingIntent.getService(
+        val stopPendingIntent = PendingIntent.getForegroundService(
             context,
             0,
             stopIntent,

--- a/app/src/main/java/com/OxGames/Pluvia/service/SteamService.kt
+++ b/app/src/main/java/com/OxGames/Pluvia/service/SteamService.kt
@@ -1099,7 +1099,7 @@ class SteamService : Service(), IChallengeUrlChanged {
     override fun onCreate() {
         super.onCreate()
         instance = this
-        
+
         PluviaApp.events.on<AndroidEvent.EndProcess, Unit>(onEndProcess)
 
         notificationHelper = NotificationHelper(applicationContext)

--- a/app/src/main/java/com/OxGames/Pluvia/service/SteamService.kt
+++ b/app/src/main/java/com/OxGames/Pluvia/service/SteamService.kt
@@ -1099,6 +1099,8 @@ class SteamService : Service(), IChallengeUrlChanged {
     override fun onCreate() {
         super.onCreate()
         instance = this
+        
+        PluviaApp.events.on<AndroidEvent.EndProcess, Unit>(onEndProcess)
 
         notificationHelper = NotificationHelper(applicationContext)
 
@@ -1118,8 +1120,6 @@ class SteamService : Service(), IChallengeUrlChanged {
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
-        PluviaApp.events.on<AndroidEvent.EndProcess, Unit>(onEndProcess)
-
         // Notification intents
         when (intent?.action) {
             NotificationHelper.ACTION_EXIT -> {

--- a/app/src/main/java/com/OxGames/Pluvia/service/SteamService.kt
+++ b/app/src/main/java/com/OxGames/Pluvia/service/SteamService.kt
@@ -1117,6 +1117,8 @@ class SteamService : Service(), IChallengeUrlChanged {
         // Notification intents
         when (intent?.action) {
             NotificationHelper.ACTION_EXIT -> {
+                Timber.d("Exiting app via notification intent")
+                SteamService.stop()
                 PluviaApp.events.emit(AndroidEvent.EndProcess)
                 return START_NOT_STICKY
             }


### PR DESCRIPTION
It seems when the app isnt in focus; meaning when in another app or swiped away from recents, the service never stopped when the exit intent is called. 