### PR TITLE
Padding fixes

### DIFF
--- a/app/src/main/java/com/OxGames/Pluvia/ui/screen/friends/FriendStickyHeader.kt
+++ b/app/src/main/java/com/OxGames/Pluvia/ui/screen/friends/FriendStickyHeader.kt
@@ -18,9 +18,15 @@ import com.OxGames.Pluvia.ui.theme.PluviaTheme
 import `in`.dragonbra.javasteam.enums.EPersonaState
 
 @Composable
-fun StickyHeaderItem(isCollapsed: Boolean, header: String, count: Int, onHeaderAction: () -> Unit) {
+fun StickyHeaderItem(
+    modifier: Modifier = Modifier,
+    isCollapsed: Boolean,
+    header: String,
+    count: Int,
+    onHeaderAction: () -> Unit,
+) {
     ListItem(
-        modifier = Modifier.clickable(onClick = onHeaderAction),
+        modifier = modifier.clickable(onClick = onHeaderAction),
         headlineContent = { Text(text = "$header ($count)") },
         trailingContent = {
             val button = when (isCollapsed) {

--- a/app/src/main/java/com/OxGames/Pluvia/ui/screen/friends/FriendsScreen.kt
+++ b/app/src/main/java/com/OxGames/Pluvia/ui/screen/friends/FriendsScreen.kt
@@ -256,10 +256,13 @@ private fun FriendsListPane(
     ) { paddingValues ->
         LazyColumn(
             modifier = Modifier
-                .padding(paddingValues)
+                .padding(
+                    top = paddingValues.calculateTopPadding(),
+                    bottom = paddingValues.calculateBottomPadding(),
+                )
                 .fillMaxSize(),
             state = listState,
-            contentPadding = PaddingValues(bottom = 72.dp), // Extra space for fab
+            contentPadding = PaddingValues(bottom = 72.dp),
         ) {
             state.friendsList.forEach { (key, value) ->
                 stickyHeader {

--- a/app/src/main/java/com/OxGames/Pluvia/ui/screen/library/LibraryScreen.kt
+++ b/app/src/main/java/com/OxGames/Pluvia/ui/screen/library/LibraryScreen.kt
@@ -20,9 +20,11 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.OxGames.Pluvia.PrefManager
 import com.OxGames.Pluvia.data.LibraryItem
 import com.OxGames.Pluvia.service.SteamService
 import com.OxGames.Pluvia.ui.data.LibraryState
@@ -137,6 +139,8 @@ private fun LibraryScreenContent(
 @Composable
 private fun Preview_LibraryScreenContent() {
     val sheetState = rememberModalBottomSheetState()
+    val context = LocalContext.current
+    PrefManager.init(context)
     var state by remember {
         mutableStateOf(
             LibraryState(

--- a/app/src/main/java/com/OxGames/Pluvia/ui/screen/library/components/LibraryList.kt
+++ b/app/src/main/java/com/OxGames/Pluvia/ui/screen/library/components/LibraryList.kt
@@ -20,6 +20,7 @@ import com.OxGames.Pluvia.data.LibraryItem
 
 @Composable
 internal fun LibraryList(
+    modifier: Modifier = Modifier,
     contentPaddingValues: PaddingValues,
     listState: LazyListState,
     list: List<LibraryItem>,
@@ -27,7 +28,7 @@ internal fun LibraryList(
 ) {
     if (list.isEmpty()) {
         Box(
-            modifier = Modifier.fillMaxSize(),
+            modifier = modifier.fillMaxSize(),
             contentAlignment = Alignment.Center,
         ) {
             Surface(
@@ -44,7 +45,7 @@ internal fun LibraryList(
         }
     } else {
         LazyColumn(
-            modifier = Modifier.fillMaxSize(),
+            modifier = modifier.fillMaxSize(),
             state = listState,
             contentPadding = contentPaddingValues,
         ) {


### PR DESCRIPTION
This PR fixes a couple of padding & layout issues. 

- Properly fix the hotfix from 1.3.1 for devices with display cutouts. The library list items should be able to scroll beneath the search bar, but disappear when it touches the status bar. 
- Fix library list items not filling their entire width when in landscape. 
- Fix friend list items not filling their entire width when in landscape. 
- Init preferences in previews, allowing them to show up in AS. 

This can be tested by adding `Modifier.border(1.dp, Color.Red)` on composables that fill the screen. 