### PR TITLE
Lower minimum api to 28

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -168,13 +168,13 @@ dependencies {
         }
     }
     implementation(libs.spongycastle)
+    implementation(libs.zstd.jni) { artifact { type = "aar" } }
 
     // Split Modules
     implementation(libs.bundles.google)
 
     // Winlator
     implementation(libs.bundles.winlator)
-    implementation(libs.zstd.jni) { artifact { type = "aar" } }
 
     // Jetpack Compose
     implementation(platform(libs.androidx.compose.bom))

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -39,8 +39,9 @@ android {
     defaultConfig {
         applicationId = "com.OxGames.Pluvia"
 
-        minSdk = 29
-        targetSdk = 34
+        minSdk = 28
+        //noinspection ExpiredTargetSdkVersion
+        targetSdk = 28
 
         versionCode = 7
         versionName = "1.3.2"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,9 +11,15 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.READ_LOGS" />
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+
+    <!--
+        - android:requestLegacyExternalStorage="true" allows us to access the devices user storage with API 28.
+        - android:usesCleartextTraffic="true" allows us to talk to HTTP only CDNs from Steam.
+        - android:windowSoftInputMode must always be in the activity block. This solves IME resizing issues.
+    -->
 
     <application
         android:name=".PluviaApp"
@@ -22,14 +28,11 @@
         android:icon="${icon}"
         android:isGame="true"
         android:label="@string/app_name"
+        android:requestLegacyExternalStorage="true"
         android:roundIcon="${roundIcon}"
         android:supportsRtl="true"
         android:theme="@style/Theme.Pluvia"
         android:usesCleartextTraffic="true">
-        <!--
-         android:windowSoftInputMode must always be in the activity block.
-         IME padding with composables like 'Scaffold' will have terrible resizing consequences, if in the activity tag.
-        -->
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,7 +11,9 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.READ_LOGS" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
 
     <application
         android:name=".PluviaApp"

--- a/app/src/main/java/com/OxGames/Pluvia/MainActivity.kt
+++ b/app/src/main/java/com/OxGames/Pluvia/MainActivity.kt
@@ -51,22 +51,25 @@ class MainActivity : ComponentActivity() {
     }
 
     private val onSetSystemUi: (AndroidEvent.SetSystemUIVisibility) -> Unit = {
+        Timber.i("onSetSystemUi: ${it.visible}")
         AppUtils.hideSystemUI(this, !it.visible)
     }
 
     private val onSetAllowedOrientation: (AndroidEvent.SetAllowedOrientation) -> Unit = {
-        // Log.d("MainActivity", "Requested allowed orientations of $it")
+        Timber.i("onSetAllowedOrientation called: $it")
         availableOrientations = it.orientations
         setOrientationTo(currentOrientationChangeValue, availableOrientations)
     }
 
     private val onStartOrientator: (AndroidEvent.StartOrientator) -> Unit = {
+        Timber.i("onStartOrientator called")
         // TODO: When rotating the device on login screen:
         //  StrictMode policy violation: android.os.strictmode.LeakedClosableViolation: A resource was acquired at attached stack trace but never released. See java.io.Closeable for information on avoiding resource leaks.
         startOrientator()
     }
 
     private val onEndProcess: (AndroidEvent.EndProcess) -> Unit = {
+        Timber.i("onEndProcess called")
         finishAndRemoveTask()
     }
 
@@ -87,6 +90,7 @@ class MainActivity : ComponentActivity() {
             val permissionLauncher = rememberLauncherForActivityResult(
                 contract = ActivityResultContracts.RequestPermission(),
             ) { isGranted ->
+                Timber.i("Notification permission was granted: $isGranted")
                 hasNotificationPermission = isGranted
             }
 
@@ -139,7 +143,7 @@ class MainActivity : ComponentActivity() {
         PluviaApp.events.off<AndroidEvent.SetAllowedOrientation, Unit>(onSetAllowedOrientation)
         PluviaApp.events.off<AndroidEvent.EndProcess, Unit>(onEndProcess)
 
-        Timber.d(
+        Timber.i(
             "onDestroy - Index: %d, Connected: %b, Logged-In: %b, Changing-Config: %b",
             index,
             SteamService.isConnected,

--- a/app/src/main/java/com/OxGames/Pluvia/PrefManager.kt
+++ b/app/src/main/java/com/OxGames/Pluvia/PrefManager.kt
@@ -16,7 +16,6 @@ import com.OxGames.Pluvia.enums.AppFilter
 import com.OxGames.Pluvia.enums.AppTheme
 import com.OxGames.Pluvia.enums.HomeDestination
 import com.OxGames.Pluvia.enums.Orientation
-import com.OxGames.Pluvia.service.SteamService
 import com.OxGames.Pluvia.utils.application.Crypto
 import com.materialkolor.PaletteStyle
 import com.winlator.box86_64.Box86_64Preset
@@ -305,20 +304,6 @@ object PrefManager {
     // endregion
 
     // region Login Info
-    private val APP_INSTALL_PATH = stringPreferencesKey("app_install_path")
-    var appInstallPath: String
-        get() = getPref(APP_INSTALL_PATH, SteamService.defaultAppInstallPath)
-        set(value) {
-            setPref(APP_INSTALL_PATH, value)
-        }
-
-    private val APP_STAGING_PATH = stringPreferencesKey("app_staging_path")
-    var appStagingPath: String
-        get() = getPref(APP_STAGING_PATH, SteamService.defaultAppStagingPath)
-        set(value) {
-            setPref(APP_STAGING_PATH, value)
-        }
-
     // Special: Because null value.
     private val CLIENT_ID = longPreferencesKey("client_id")
     var clientId: Long?

--- a/app/src/main/java/com/OxGames/Pluvia/events/AndroidEvent.kt
+++ b/app/src/main/java/com/OxGames/Pluvia/events/AndroidEvent.kt
@@ -9,7 +9,10 @@ interface AndroidEvent<T> : Event<T> {
     data class SetAllowedOrientation(val orientations: EnumSet<Orientation>) : AndroidEvent<Unit>
     data class SetSystemUIVisibility(val visible: Boolean) : AndroidEvent<Unit>
     data object ActivityDestroyed : AndroidEvent<Unit>
+
+    @Deprecated("BackPressed doesn't seem to have a use case")
     data object BackPressed : AndroidEvent<Unit>
+
     data object EndProcess : AndroidEvent<Unit>
     data object GuestProgramTerminated : AndroidEvent<Unit>
     data object StartOrientator : AndroidEvent<Unit>

--- a/app/src/main/java/com/OxGames/Pluvia/service/SteamService.kt
+++ b/app/src/main/java/com/OxGames/Pluvia/service/SteamService.kt
@@ -1062,7 +1062,7 @@ class SteamService : Service(), IChallengeUrlChanged {
         // Notification intents
         when (intent?.action) {
             NotificationHelper.ACTION_EXIT -> {
-                Timber.d("Exiting app via notification intent")
+                Timber.i("Exiting app via notification intent")
 
                 val event = AndroidEvent.EndProcess
                 PluviaApp.events.emit(event)

--- a/app/src/main/java/com/OxGames/Pluvia/service/SteamService.kt
+++ b/app/src/main/java/com/OxGames/Pluvia/service/SteamService.kt
@@ -3,6 +3,7 @@ package com.OxGames.Pluvia.service
 import android.app.Service
 import android.content.Context
 import android.content.Intent
+import android.os.Environment
 import android.os.IBinder
 import androidx.room.withTransaction
 import com.OxGames.Pluvia.BuildConfig
@@ -103,7 +104,6 @@ import `in`.dragonbra.javasteam.util.NetHelpers
 import `in`.dragonbra.javasteam.util.log.LogListener
 import `in`.dragonbra.javasteam.util.log.LogManager
 import java.io.Closeable
-import java.io.File
 import java.nio.file.Files
 import java.nio.file.Paths
 import java.util.Collections
@@ -111,6 +111,8 @@ import java.util.EnumSet
 import java.util.concurrent.CancellationException
 import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Inject
+import kotlin.io.path.ExperimentalPathApi
+import kotlin.io.path.deleteRecursively
 import kotlin.io.path.pathString
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.CoroutineScope
@@ -193,6 +195,15 @@ class SteamService : Service(), IChallengeUrlChanged {
     private var familyGroupMembers: ArrayList<Int> = arrayListOf()
 
     companion object {
+        /* Main File Location */
+        private val baseDir by lazy { Environment.getExternalStorageDirectory().absolutePath }
+        private val pluviaPath by lazy { Paths.get(baseDir, "Pluvia") } // Yes, this is hardcoded for now.
+        private val steamPath by lazy { pluviaPath.resolve("Steam") }
+        private val depotManifestsPath by lazy { steamPath.resolve("depot_manifests.zip") }
+        private val defaultAppInstallPath by lazy { steamPath.resolve("steamapps/common") }
+        private val defaultAppStagingPath by lazy { steamPath.resolve("steamapps/staging") }
+        private val serverListPath by lazy { instance!!.cacheDir.toPath().resolve("server_list.bin") }
+
         private val PICS_CHANGE_CHECK_DELAY = 60.seconds
 
         const val MAX_SIMULTANEOUS_PICS_REQUESTS = 50
@@ -233,44 +244,6 @@ class SteamService : Service(), IChallengeUrlChanged {
             get() = instance?.steamClient?.steamID?.isValid == true
         var isWaitingForQRAuth: Boolean = false
             private set
-
-        // 'cached' variables are a hack to fix 'DiskReadViolation'
-
-        private var cachedServerListPath: String? = null
-        private val serverListPath: String
-            get() {
-                cachedServerListPath?.let { return it }
-                val value = Paths.get(instance!!.cacheDir.path, "server_list.bin").pathString
-                cachedServerListPath = value
-                return value
-            }
-
-        private var cachedDepotManifestsPath: String? = null
-        private val depotManifestsPath: String
-            get() {
-                cachedDepotManifestsPath?.let { return it }
-                val value = Paths.get(instance!!.dataDir.path, "Steam", "depot_manifests.zip").pathString
-                cachedDepotManifestsPath = value
-                return value
-            }
-
-        private var cachedDefaultAppInstallPath: String? = null
-        val defaultAppInstallPath: String
-            get() {
-                cachedDefaultAppInstallPath?.let { return it }
-                val value = Paths.get(instance!!.dataDir.path, "Steam", "steamapps", "common").pathString
-                cachedDefaultAppInstallPath = value
-                return value
-            }
-
-        private var cachedDefaultAppStagingPath: String? = null
-        val defaultAppStagingPath: String
-            get() {
-                cachedDefaultAppStagingPath?.let { return it }
-                val value = Paths.get(instance!!.dataDir.path, "Steam", "steamapps", "staging").pathString
-                cachedDefaultAppStagingPath = value
-                return value
-            }
 
         val userSteamId: SteamID?
             get() = instance?.steamClient?.steamID
@@ -386,10 +359,11 @@ class SteamService : Service(), IChallengeUrlChanged {
                 appName = getAppInfoOf(appId)?.name.orEmpty()
             }
 
-            return Paths.get(PrefManager.appInstallPath, appName).pathString
+            return defaultAppInstallPath.resolve(appName).pathString
         }
 
-        fun deleteApp(appId: Int): Boolean {
+        @OptIn(ExperimentalPathApi::class)
+        fun deleteApp(appId: Int) {
             with(instance!!) {
                 scope.launch {
                     db.withTransaction {
@@ -403,7 +377,7 @@ class SteamService : Service(), IChallengeUrlChanged {
 
             appCache.remove(appId)
 
-            return File(appDirPath).deleteRecursively()
+            Paths.get(appDirPath).deleteRecursively()
         }
 
         fun downloadApp(appId: Int): DownloadInfo? {
@@ -513,8 +487,8 @@ class SteamService : Service(), IChallengeUrlChanged {
                                 ContentDownloader(instance!!.steamClient!!).downloadApp(
                                     appId = appId,
                                     depotId = depotId,
-                                    installPath = PrefManager.appInstallPath,
-                                    stagingPath = PrefManager.appStagingPath,
+                                    installPath = defaultAppInstallPath.pathString,
+                                    stagingPath = defaultAppStagingPath.pathString,
                                     branch = branch,
                                     // maxDownloads = 1,
                                     onDownloadProgress = { downloadInfo.setProgress(it, jobIndex + indexOffset) },
@@ -1077,8 +1051,8 @@ class SteamService : Service(), IChallengeUrlChanged {
             val configuration = SteamConfiguration.create {
                 it.withProtocolTypes(PROTOCOL_TYPES)
                 it.withCellID(PrefManager.cellId)
-                it.withServerListProvider(FileServerListProvider(File(serverListPath)))
-                it.withManifestProvider(FileManifestProvider(File(depotManifestsPath)))
+                it.withServerListProvider(FileServerListProvider(serverListPath))
+                it.withManifestProvider(FileManifestProvider(depotManifestsPath))
             }
 
             // create our steam client instance
@@ -1211,9 +1185,6 @@ class SteamService : Service(), IChallengeUrlChanged {
         isConnected = false
         isLoggingOut = false
         isWaitingForQRAuth = false
-
-        PrefManager.appInstallPath = defaultAppInstallPath
-        PrefManager.appStagingPath = defaultAppStagingPath
 
         steamClient = null
         _steamUser = null

--- a/app/src/main/java/com/OxGames/Pluvia/service/SteamService.kt
+++ b/app/src/main/java/com/OxGames/Pluvia/service/SteamService.kt
@@ -1136,6 +1136,7 @@ class SteamService : Service(), IChallengeUrlChanged {
 
     override fun onBind(intent: Intent?): IBinder? = null
 
+    // TODO this gets called to fast (and too many times) when there is no WIFI connection?
     private fun connectToSteam() {
         CoroutineScope(Dispatchers.Default).launch {
             // this call errors out if run on the main thread

--- a/app/src/main/java/com/OxGames/Pluvia/service/SteamService.kt
+++ b/app/src/main/java/com/OxGames/Pluvia/service/SteamService.kt
@@ -198,7 +198,7 @@ class SteamService : Service(), IChallengeUrlChanged {
         /* Main File Location */
         private val baseDir by lazy { Environment.getExternalStorageDirectory().absolutePath }
         private val pluviaPath by lazy { Paths.get(baseDir, "Pluvia") } // Yes, this is hardcoded for now.
-        private val steamPath by lazy { pluviaPath.resolve("Steam") }
+        val steamPath by lazy { pluviaPath.resolve("Steam") }
         private val depotManifestsPath by lazy { steamPath.resolve("depot_manifests.zip") }
         private val defaultAppInstallPath by lazy { steamPath.resolve("steamapps/common") }
         private val defaultAppStagingPath by lazy { steamPath.resolve("steamapps/staging") }

--- a/app/src/main/java/com/OxGames/Pluvia/ui/PluviaMain.kt
+++ b/app/src/main/java/com/OxGames/Pluvia/ui/PluviaMain.kt
@@ -184,12 +184,14 @@ fun PluviaMain(
 
     LaunchedEffect(lifecycleOwner) {
         if (!state.isSteamConnected) {
+            Timber.i("Starting Steam service.")
             val intent = Intent(context, SteamService::class.java)
             context.startForegroundService(intent)
         }
 
         // Go to the Home screen if we're already logged in.
         if (SteamService.isLoggedIn && state.currentScreen == PluviaScreen.LoginUser) {
+            Timber.i("Navigating to Home")
             navController.navigate(PluviaScreen.Home.route)
         }
     }

--- a/app/src/main/java/com/OxGames/Pluvia/ui/screen/library/LibraryAppScreen.kt
+++ b/app/src/main/java/com/OxGames/Pluvia/ui/screen/library/LibraryAppScreen.kt
@@ -4,7 +4,6 @@ import android.Manifest
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.content.res.Configuration
-import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.Crossfade
@@ -34,6 +33,8 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.SnackbarResult
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
@@ -44,6 +45,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -97,10 +99,13 @@ import timber.log.Timber
 @Composable
 fun AppScreen(
     appId: Int,
+    snackBarHost: SnackbarHostState,
     onClickPlay: (Boolean) -> Unit,
     onBack: () -> Unit,
 ) {
     val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+
     var downloadInfo by remember(appId) {
         mutableStateOf(SteamService.getAppDownloadInfo(appId))
     }
@@ -209,7 +214,18 @@ fun AppScreen(
                 }
             } else {
                 // Snack bar this?
-                Toast.makeText(context, "Storage permission required", Toast.LENGTH_SHORT).show()
+                scope.launch {
+                    val result = snackBarHost.showSnackbar(
+                        message = context.getString(R.string.snack_permissions_needed),
+                        actionLabel = context.getString(R.string.settings),
+                    )
+                    when (result) {
+                        SnackbarResult.Dismissed -> Unit
+                        SnackbarResult.ActionPerformed -> {
+                            FileUtils.openAppSettings(context)
+                        }
+                    }
+                }
             }
         },
     )

--- a/app/src/main/java/com/OxGames/Pluvia/ui/screen/library/LibraryAppScreen.kt
+++ b/app/src/main/java/com/OxGames/Pluvia/ui/screen/library/LibraryAppScreen.kt
@@ -213,7 +213,6 @@ fun AppScreen(
                     )
                 }
             } else {
-                // Snack bar this?
                 scope.launch {
                     val result = snackBarHost.showSnackbar(
                         message = context.getString(R.string.snack_permissions_needed),

--- a/app/src/main/java/com/OxGames/Pluvia/ui/screen/library/LibraryAppScreen.kt
+++ b/app/src/main/java/com/OxGames/Pluvia/ui/screen/library/LibraryAppScreen.kt
@@ -93,8 +93,6 @@ import timber.log.Timber
 
 // https://partner.steamgames.com/doc/store/assets/libraryassets#4
 
-// TODO: How to deal with games in data/data location. Wipe or Move?
-
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun AppScreen(

--- a/app/src/main/java/com/OxGames/Pluvia/ui/screen/library/LibraryAppScreen.kt
+++ b/app/src/main/java/com/OxGames/Pluvia/ui/screen/library/LibraryAppScreen.kt
@@ -295,7 +295,7 @@ fun AppScreen(
                     )
                 } else if (!isInstalled) {
                     val depots = SteamService.getDownloadableDepots(appId)
-                    Timber.d("There are ${depots.size} depots belonging to $appId")
+                    Timber.i("There are ${depots.size} depots belonging to $appId")
                     // TODO: get space available based on where user wants to install
                     val availableBytes =
                         FileUtils.getAvailableSpace(context.filesDir.absolutePath)

--- a/app/src/main/java/com/OxGames/Pluvia/ui/screen/library/LibraryScreen.kt
+++ b/app/src/main/java/com/OxGames/Pluvia/ui/screen/library/LibraryScreen.kt
@@ -57,6 +57,7 @@ import com.OxGames.Pluvia.ui.component.data.fakeAppInfo
 import com.OxGames.Pluvia.ui.screen.library.components.LibraryDetailPane
 import com.OxGames.Pluvia.ui.screen.library.components.LibraryListPane
 import com.OxGames.Pluvia.ui.theme.PluviaTheme
+import com.OxGames.Pluvia.utils.ContainerUtils
 import com.OxGames.Pluvia.utils.FileUtils
 import java.nio.file.Paths
 import kotlin.io.path.exists
@@ -123,7 +124,10 @@ fun HomeLibraryScreen(
                         total = totalFiles
                     },
                     onComplete = {
-                        showMoveDialog = false
+                        scope.launch {
+                            ContainerUtils.migrateDefaultDrives(context)
+                            showMoveDialog = false
+                        }
                     },
                 )
             }
@@ -266,7 +270,7 @@ private fun GameMigrationDialog(
         title = { Text(text = "Moving Files") },
         text = {
             val currentProgress by remember(movedFiles, totalFiles) {
-                mutableFloatStateOf(movedFiles.toFloat() / totalFiles)
+                mutableFloatStateOf(movedFiles.plus(1).toFloat() / totalFiles)
             }
             Column(
                 modifier = Modifier

--- a/app/src/main/java/com/OxGames/Pluvia/ui/screen/library/LibraryScreen.kt
+++ b/app/src/main/java/com/OxGames/Pluvia/ui/screen/library/LibraryScreen.kt
@@ -242,7 +242,6 @@ private fun LibraryScreenContent(
             AnimatedPane {
                 LibraryDetailPane(
                     appId = appId,
-                    snackBarHost = snackBarHost,
                     onBack = {
                         // We're still in Adaptive navigation.
                         scope.launch {

--- a/app/src/main/java/com/OxGames/Pluvia/ui/screen/library/LibraryScreen.kt
+++ b/app/src/main/java/com/OxGames/Pluvia/ui/screen/library/LibraryScreen.kt
@@ -86,7 +86,6 @@ fun HomeLibraryScreen(
         mutableStateOf(path)
     }
     var showMoveDialog by remember { mutableStateOf(false) }
-    var progress by remember { mutableFloatStateOf(0f) }
     var current by remember { mutableStateOf("") }
     var total by remember { mutableIntStateOf(0) }
     var moved by remember { mutableIntStateOf(0) }
@@ -118,9 +117,8 @@ fun HomeLibraryScreen(
                 FileUtils.moveGamesFromOldPath(
                     oldGamesDirectory.pathString,
                     SteamService.steamPath.pathString,
-                    onProgressUpdate = { currentFile, fileProgress, movedFiles, totalFiles ->
+                    onProgressUpdate = { currentFile, movedFiles, totalFiles ->
                         current = currentFile
-                        progress = fileProgress
                         moved = movedFiles
                         total = totalFiles
                     },
@@ -134,7 +132,6 @@ fun HomeLibraryScreen(
 
     if (showMoveDialog) {
         GameMigrationDialog(
-            progress = progress,
             currentFile = current,
             movedFiles = moved,
             totalFiles = total,
@@ -257,7 +254,6 @@ private fun LibraryScreenContent(
 
 @Composable
 private fun GameMigrationDialog(
-    progress: Float,
     currentFile: String,
     movedFiles: Int,
     totalFiles: Int,
@@ -269,6 +265,9 @@ private fun GameMigrationDialog(
         icon = { Icon(imageVector = Icons.Default.ContentCopy, contentDescription = null) },
         title = { Text(text = "Moving Files") },
         text = {
+            val currentProgress by remember(movedFiles, totalFiles) {
+                mutableFloatStateOf(movedFiles.toFloat() / totalFiles)
+            }
             Column(
                 modifier = Modifier
                     .padding(16.dp)
@@ -292,13 +291,13 @@ private fun GameMigrationDialog(
 
                 LinearProgressIndicator(
                     modifier = Modifier.fillMaxWidth(),
-                    progress = { progress },
+                    progress = { currentProgress },
                 )
 
                 Spacer(modifier = Modifier.height(16.dp))
 
                 Text(
-                    text = "${(progress * 100).roundToInt()}%",
+                    text = "${(currentProgress * 100).roundToInt()}%",
                     style = MaterialTheme.typography.bodyMedium,
                 )
             }
@@ -316,10 +315,9 @@ private fun GameMigrationDialog(
 private fun Preview_GameMigrationDialog() {
     PluviaTheme {
         GameMigrationDialog(
-            progress = .45f,
-            currentFile = "Pluvia",
-            movedFiles = 16,
-            totalFiles = 64,
+            currentFile = "Pluvia.txt",
+            movedFiles = 75,
+            totalFiles = 100,
         )
     }
 }

--- a/app/src/main/java/com/OxGames/Pluvia/ui/screen/library/LibraryScreen.kt
+++ b/app/src/main/java/com/OxGames/Pluvia/ui/screen/library/LibraryScreen.kt
@@ -1,10 +1,7 @@
 package com.OxGames.Pluvia.ui.screen.library
 
 import android.Manifest
-import android.content.Intent
 import android.content.res.Configuration
-import android.net.Uri
-import android.provider.Settings
 import androidx.activity.compose.BackHandler
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
@@ -102,18 +99,14 @@ fun HomeLibraryScreen(
             if (!writePermissionGranted && !readPermissionGranted) {
                 scope.launch {
                     val result = snackBarHost.showSnackbar(
-                        message = "Storage permission is needed to move and download games",
-                        actionLabel = context.getString(R.string.ok),
+                        message = context.getString(R.string.snack_permissions_needed),
+                        actionLabel = context.getString(R.string.settings),
                     )
 
                     when (result) {
                         SnackbarResult.Dismissed -> Unit
                         SnackbarResult.ActionPerformed -> {
-                            val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
-                                data = Uri.fromParts("package", context.packageName, null)
-                                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-                            }
-                            context.startActivity(intent)
+                            FileUtils.openAppSettings(context)
                         }
                     }
                 }
@@ -248,6 +241,7 @@ private fun LibraryScreenContent(
             AnimatedPane {
                 LibraryDetailPane(
                     appId = appId,
+                    snackBarHost = snackBarHost,
                     onBack = {
                         // We're still in Adaptive navigation.
                         scope.launch {

--- a/app/src/main/java/com/OxGames/Pluvia/ui/screen/library/LibraryScreen.kt
+++ b/app/src/main/java/com/OxGames/Pluvia/ui/screen/library/LibraryScreen.kt
@@ -1,12 +1,30 @@
 package com.OxGames.Pluvia.ui.screen.library
 
+import android.Manifest
 import android.content.res.Configuration
 import androidx.activity.compose.BackHandler
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.displayCutoutPadding
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ContentCopy
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SheetState
+import androidx.compose.material3.SnackbarDuration
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.SnackbarResult
+import androidx.compose.material3.Text
 import androidx.compose.material3.adaptive.ExperimentalMaterial3AdaptiveApi
 import androidx.compose.material3.adaptive.layout.AnimatedPane
 import androidx.compose.material3.adaptive.layout.ListDetailPaneScaffold
@@ -15,14 +33,19 @@ import androidx.compose.material3.adaptive.navigation.BackNavigationBehavior
 import androidx.compose.material3.adaptive.navigation.rememberListDetailPaneScaffoldNavigator
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.OxGames.Pluvia.PrefManager
@@ -33,6 +56,11 @@ import com.OxGames.Pluvia.ui.component.data.fakeAppInfo
 import com.OxGames.Pluvia.ui.screen.library.components.LibraryDetailPane
 import com.OxGames.Pluvia.ui.screen.library.components.LibraryListPane
 import com.OxGames.Pluvia.ui.theme.PluviaTheme
+import com.OxGames.Pluvia.utils.FileUtils
+import java.nio.file.Paths
+import kotlin.io.path.exists
+import kotlin.io.path.pathString
+import kotlin.math.roundToInt
 import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -45,9 +73,84 @@ fun HomeLibraryScreen(
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    val snackBarHost = remember { SnackbarHostState() }
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+
+    /**
+     * Games Migration, to be removed in a future update.
+     */
+    val oldGamesDirectory by remember {
+        val path = Paths.get(context.dataDir.path, "Steam")
+        mutableStateOf(path)
+    }
+    var showMoveDialog by remember { mutableStateOf(false) }
+    var progress by remember { mutableFloatStateOf(0f) }
+    var current by remember { mutableStateOf("") }
+    var total by remember { mutableIntStateOf(0) }
+    var moved by remember { mutableIntStateOf(0) }
+
+    val permissionLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.RequestMultiplePermissions(),
+        onResult = { permission ->
+            scope.launch {
+                showMoveDialog = true
+                FileUtils.moveGamesFromOldPath(
+                    oldGamesDirectory.pathString,
+                    SteamService.steamPath.pathString,
+                    onProgressUpdate = { currentFile, fileProgress, movedFiles, totalFiles ->
+                        current = currentFile
+                        progress = fileProgress
+                        moved = movedFiles
+                        total = totalFiles
+                    },
+                    onComplete = {
+                        showMoveDialog = false
+                    },
+                )
+            }
+        },
+    )
+
+    if (showMoveDialog) {
+        GameMigrationDialog(
+            progress = progress,
+            currentFile = current,
+            movedFiles = moved,
+            totalFiles = total,
+        )
+    }
+    LaunchedEffect(Unit) {
+        val directoryExists = oldGamesDirectory.exists()
+
+        if (directoryExists) {
+            val result = snackBarHost.showSnackbar(
+                message = "Games directory has moved, move existing games?",
+                actionLabel = "Move",
+                withDismissAction = true,
+            )
+
+            when (result) {
+                SnackbarResult.Dismissed -> snackBarHost.showSnackbar(
+                    message = "Games in old directory won't be playable until moved.",
+                    duration = SnackbarDuration.Long,
+                )
+
+                SnackbarResult.ActionPerformed -> {
+                    permissionLauncher.launch(
+                        arrayOf(
+                            Manifest.permission.READ_EXTERNAL_STORAGE,
+                            Manifest.permission.WRITE_EXTERNAL_STORAGE,
+                        ),
+                    )
+                }
+            }
+        }
+    }
 
     LibraryScreenContent(
         state = state,
+        snackBarHost = snackBarHost,
         listState = viewModel.listState,
         sheetState = sheetState,
         onFilterChanged = viewModel::onFilterChanged,
@@ -64,6 +167,7 @@ fun HomeLibraryScreen(
 @Composable
 private fun LibraryScreenContent(
     state: LibraryState,
+    snackBarHost: SnackbarHostState,
     listState: LazyListState,
     sheetState: SheetState,
     onFilterChanged: (AppFilter) -> Unit,
@@ -92,6 +196,7 @@ private fun LibraryScreenContent(
             AnimatedPane {
                 LibraryListPane(
                     state = state,
+                    snackBarHost = snackBarHost,
                     listState = listState,
                     sheetState = sheetState,
                     onFilterChanged = onFilterChanged,
@@ -129,9 +234,74 @@ private fun LibraryScreenContent(
     )
 }
 
+@Composable
+private fun GameMigrationDialog(
+    progress: Float,
+    currentFile: String,
+    movedFiles: Int,
+    totalFiles: Int,
+) {
+    AlertDialog(
+        onDismissRequest = {
+            // We don't allow dismissal during move.
+        },
+        icon = { Icon(imageVector = Icons.Default.ContentCopy, contentDescription = null) },
+        title = { Text(text = "Moving Files") },
+        text = {
+            Column(
+                modifier = Modifier
+                    .padding(16.dp)
+                    .fillMaxWidth(),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                Text(
+                    text = "File ${movedFiles + 1} of $totalFiles",
+                    style = MaterialTheme.typography.bodyLarge,
+                )
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                Text(
+                    text = currentFile,
+                    style = MaterialTheme.typography.bodyMedium,
+                    maxLines = 1,
+                )
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                LinearProgressIndicator(
+                    modifier = Modifier.fillMaxWidth(),
+                    progress = { progress },
+                )
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                Text(
+                    text = "${(progress * 100).roundToInt()}%",
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+            }
+        },
+        confirmButton = {},
+    )
+}
+
 /***********
  * PREVIEW *
  ***********/
+
+@Preview(uiMode = Configuration.UI_MODE_NIGHT_YES or Configuration.UI_MODE_TYPE_NORMAL)
+@Composable
+private fun Preview_GameMigrationDialog() {
+    PluviaTheme {
+        GameMigrationDialog(
+            progress = .45f,
+            currentFile = "Pluvia",
+            movedFiles = 16,
+            totalFiles = 64,
+        )
+    }
+}
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Preview(uiMode = Configuration.UI_MODE_NIGHT_YES or Configuration.UI_MODE_TYPE_NORMAL)
@@ -167,6 +337,7 @@ private fun Preview_LibraryScreenContent() {
         LibraryScreenContent(
             listState = rememberLazyListState(),
             state = state,
+            snackBarHost = SnackbarHostState(),
             sheetState = sheetState,
             onIsSearching = {},
             onSearchQuery = {},

--- a/app/src/main/java/com/OxGames/Pluvia/ui/screen/library/LibraryState.kt
+++ b/app/src/main/java/com/OxGames/Pluvia/ui/screen/library/LibraryState.kt
@@ -10,6 +10,7 @@ data class LibraryState(
     val appInfoList: List<LibraryItem> = emptyList(),
     val modalBottomSheet: Boolean = false,
 
+    val isLoading: Boolean = false,
     val isSearching: Boolean = false,
     val searchQuery: String = "",
 )

--- a/app/src/main/java/com/OxGames/Pluvia/ui/screen/library/LibraryViewModel.kt
+++ b/app/src/main/java/com/OxGames/Pluvia/ui/screen/library/LibraryViewModel.kt
@@ -94,10 +94,11 @@ class LibraryViewModel @Inject constructor(
     }
 
     private fun onFilterApps() {
-        Timber.tag("LibraryViewModel").d("onFilterApps")
         viewModelScope.launch {
             val currentState = _state.value
             val currentFilter = AppFilter.getAppType(currentState.appInfoSortType)
+
+            Timber.tag("LibraryViewModel").i("Current Filter is: $currentFilter")
 
             val filteredList = appList
                 .asSequence()

--- a/app/src/main/java/com/OxGames/Pluvia/ui/screen/library/components/LibraryDetailPane.kt
+++ b/app/src/main/java/com/OxGames/Pluvia/ui/screen/library/components/LibraryDetailPane.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -21,6 +22,7 @@ import com.OxGames.Pluvia.ui.theme.PluviaTheme
 @Composable
 internal fun LibraryDetailPane(
     appId: Int,
+    snackBarHost: SnackbarHostState,
     onClickPlay: (Boolean) -> Unit,
     onBack: () -> Unit,
 ) {
@@ -30,6 +32,7 @@ internal fun LibraryDetailPane(
         } else {
             AppScreen(
                 appId = appId,
+                snackBarHost = snackBarHost,
                 onClickPlay = onClickPlay,
                 onBack = onBack,
             )
@@ -64,6 +67,7 @@ private fun Preview_LibraryDetailPane() {
     PluviaTheme {
         LibraryDetailPane(
             appId = Int.MAX_VALUE,
+            snackBarHost = SnackbarHostState(),
             onClickPlay = { },
             onBack = { },
         )

--- a/app/src/main/java/com/OxGames/Pluvia/ui/screen/library/components/LibraryDetailPane.kt
+++ b/app/src/main/java/com/OxGames/Pluvia/ui/screen/library/components/LibraryDetailPane.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -22,7 +21,6 @@ import com.OxGames.Pluvia.ui.theme.PluviaTheme
 @Composable
 internal fun LibraryDetailPane(
     appId: Int,
-    snackBarHost: SnackbarHostState,
     onClickPlay: (Boolean) -> Unit,
     onBack: () -> Unit,
 ) {
@@ -32,7 +30,6 @@ internal fun LibraryDetailPane(
         } else {
             AppScreen(
                 appId = appId,
-                snackBarHost = snackBarHost,
                 onClickPlay = onClickPlay,
                 onBack = onBack,
             )
@@ -67,7 +64,6 @@ private fun Preview_LibraryDetailPane() {
     PluviaTheme {
         LibraryDetailPane(
             appId = Int.MAX_VALUE,
-            snackBarHost = SnackbarHostState(),
             onClickPlay = { },
             onBack = { },
         )

--- a/app/src/main/java/com/OxGames/Pluvia/ui/screen/library/components/LibraryListPane.kt
+++ b/app/src/main/java/com/OxGames/Pluvia/ui/screen/library/components/LibraryListPane.kt
@@ -51,6 +51,7 @@ import com.OxGames.Pluvia.ui.theme.PluviaTheme
 @Composable
 internal fun LibraryListPane(
     state: LibraryState,
+    snackBarHost: SnackbarHostState,
     listState: LazyListState,
     sheetState: SheetState,
     onFilterChanged: (AppFilter) -> Unit,
@@ -62,7 +63,6 @@ internal fun LibraryListPane(
     onSettings: () -> Unit,
 ) {
     val expandedFab by remember { derivedStateOf { listState.firstVisibleItemIndex == 0 } }
-    val snackBarHost = remember { SnackbarHostState() }
 
     // Determine the orientation to add additional scaffold padding.
     val configuration = LocalConfiguration.current
@@ -168,6 +168,7 @@ private fun Preview_LibraryListPane() {
             LibraryListPane(
                 listState = LazyListState(2, 64),
                 state = state,
+                snackBarHost = SnackbarHostState(),
                 sheetState = sheetState,
                 onFilterChanged = { },
                 onModalBottomSheet = {

--- a/app/src/main/java/com/OxGames/Pluvia/ui/screen/library/components/LibraryListPane.kt
+++ b/app/src/main/java/com/OxGames/Pluvia/ui/screen/library/components/LibraryListPane.kt
@@ -2,6 +2,7 @@ package com.OxGames.Pluvia.ui.screen.library.components
 
 import android.content.res.Configuration
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.Crossfade
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.scaleIn
@@ -41,6 +42,7 @@ import com.OxGames.Pluvia.PrefManager
 import com.OxGames.Pluvia.R
 import com.OxGames.Pluvia.data.LibraryItem
 import com.OxGames.Pluvia.enums.AppFilter
+import com.OxGames.Pluvia.ui.component.LoadingScreen
 import com.OxGames.Pluvia.ui.component.data.fakeAppInfo
 import com.OxGames.Pluvia.ui.screen.library.LibraryState
 import com.OxGames.Pluvia.ui.theme.PluviaTheme
@@ -101,14 +103,22 @@ internal fun LibraryListPane(
         Box(
             modifier = Modifier.fillMaxSize(),
         ) {
-            LibraryList(
-                list = state.appInfoList,
-                listState = listState,
-                contentPaddingValues = PaddingValues(
-                    top = paddingValues.calculateTopPadding(),
-                    bottom = 72.dp,
-                ),
-                onItemClick = onNavigate,
+            Crossfade(
+                targetState = state.isLoading,
+                content = { isLoading ->
+                    when (isLoading) {
+                        true -> LoadingScreen()
+                        false -> LibraryList(
+                            list = state.appInfoList,
+                            listState = listState,
+                            contentPaddingValues = PaddingValues(
+                                top = paddingValues.calculateTopPadding(),
+                                bottom = 72.dp,
+                            ),
+                            onItemClick = onNavigate,
+                        )
+                    }
+                },
             )
             if (state.modalBottomSheet) {
                 ModalBottomSheet(

--- a/app/src/main/java/com/OxGames/Pluvia/ui/screen/xserver/XServerViewModel.kt
+++ b/app/src/main/java/com/OxGames/Pluvia/ui/screen/xserver/XServerViewModel.kt
@@ -564,7 +564,7 @@ class XServerViewModel @Inject constructor(
         // val dxwrapper = this.dxwrapper
         if (state.value.dxwrapper == "dxvk") {
             val dxvkVersion = state.value.dxwrapperConfig?.get("version")
-            Timber.d("DXVK version: $dxvkVersion")
+            Timber.i("DXVK version: $dxvkVersion")
             _state.update { it.copy(dxwrapper = "dxvk-$dxvkVersion") }
         }
 

--- a/app/src/main/java/com/OxGames/Pluvia/utils/ContainerUtils.kt
+++ b/app/src/main/java/com/OxGames/Pluvia/utils/ContainerUtils.kt
@@ -242,7 +242,7 @@ object ContainerUtils {
             val appDirPath = SteamService.getAppDirPath(appId)
             val drive: Char = Container.getNextAvailableDriveLetter(defaultDrives)
             val drives = "$defaultDrives$drive:$appDirPath"
-            Timber.d("Prepared container drives: $drives")
+            Timber.i("Prepared container drives: $drives")
 
             val data = JSONObject()
             data.put("name", "container_$containerId")

--- a/app/src/main/java/com/OxGames/Pluvia/utils/FileUtils.kt
+++ b/app/src/main/java/com/OxGames/Pluvia/utils/FileUtils.kt
@@ -1,7 +1,11 @@
 package com.OxGames.Pluvia.utils
 
+import android.content.Context
+import android.content.Intent
 import android.content.res.AssetManager
+import android.net.Uri
 import android.os.StatFs
+import android.provider.Settings
 import java.io.BufferedReader
 import java.io.File
 import java.io.FileOutputStream
@@ -163,6 +167,14 @@ object FileUtils {
             // Timber.e(e)
             false
         }
+    }
+
+    fun openAppSettings(context: Context) {
+        val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
+            data = Uri.fromParts("package", context.packageName, null)
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+        context.startActivity(intent)
     }
 
     /**

--- a/app/src/main/java/com/OxGames/Pluvia/utils/FileUtils.kt
+++ b/app/src/main/java/com/OxGames/Pluvia/utils/FileUtils.kt
@@ -8,12 +8,21 @@ import java.io.FileOutputStream
 import java.io.FileReader
 import java.io.IOException
 import java.io.OutputStreamWriter
+import java.nio.ByteBuffer
+import java.nio.channels.FileChannel
+import java.nio.file.FileVisitResult
 import java.nio.file.Files
 import java.nio.file.Path
+import java.nio.file.Paths
+import java.nio.file.SimpleFileVisitor
+import java.nio.file.StandardCopyOption
+import java.nio.file.StandardOpenOption
+import java.nio.file.attribute.BasicFileAttributes
 import java.util.stream.Stream
-import kotlin.io.path.exists
 import kotlin.io.path.isDirectory
 import kotlin.io.path.name
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import timber.log.Timber
 
 object FileUtils {
@@ -153,6 +162,154 @@ object FileUtils {
         } catch (e: IOException) {
             // Timber.e(e)
             false
+        }
+    }
+
+    /**
+     * Move games from internal only storage to user storage.
+     * This should be removed after a few versions and just
+     * remove the old path to free up space.
+     */
+    suspend fun moveGamesFromOldPath(
+        sourceDir: String,
+        targetDir: String,
+        onProgressUpdate: (currentFile: String, fileProgress: Float, movedFiles: Int, totalFiles: Int) -> Unit,
+        onComplete: () -> Unit,
+    ) = withContext(Dispatchers.IO) {
+        try {
+            val sourcePath = Paths.get(sourceDir)
+            val targetPath = Paths.get(targetDir)
+
+            if (!Files.exists(targetPath)) {
+                Files.createDirectories(targetPath)
+            }
+
+            val allFiles = mutableListOf<Path>()
+            Files.walkFileTree(
+                sourcePath,
+                object : SimpleFileVisitor<Path>() {
+                    override fun visitFile(file: Path, attrs: BasicFileAttributes): FileVisitResult {
+                        if (Files.isRegularFile(file)) {
+                            allFiles.add(file)
+                        }
+                        return FileVisitResult.CONTINUE
+                    }
+
+                    override fun visitFileFailed(file: Path, exc: IOException): FileVisitResult {
+                        Timber.e(exc, "Failed to visit file: $file")
+                        return FileVisitResult.CONTINUE
+                    }
+                },
+            )
+
+            val totalFiles = allFiles.size
+            var filesMoved = 0
+
+            for (sourcePath in allFiles) {
+                val relativePath = sourcePath.subpath(Paths.get(sourceDir).nameCount, sourcePath.nameCount)
+                val targetFilePath = Paths.get(targetDir, relativePath.toString())
+
+                Files.createDirectories(targetFilePath.parent)
+
+                // val fileName = sourcePath.fileName.toString()
+
+                try {
+                    Files.move(sourcePath, targetFilePath, StandardCopyOption.ATOMIC_MOVE)
+
+                    withContext(Dispatchers.Main) {
+                        onProgressUpdate(relativePath.toString(), 1f, filesMoved++, totalFiles)
+                    }
+                } catch (e: Exception) {
+                    val fileSize = Files.size(sourcePath)
+                    var bytesCopied = 0L
+
+                    FileChannel.open(sourcePath, StandardOpenOption.READ).use { sourceChannel ->
+                        FileChannel.open(
+                            targetFilePath,
+                            StandardOpenOption.CREATE,
+                            StandardOpenOption.WRITE,
+                            StandardOpenOption.TRUNCATE_EXISTING,
+                        ).use { targetChannel ->
+                            val buffer = ByteBuffer.allocateDirect(8 * 1024 * 1024)
+                            var bytesRead: Int
+
+                            while (sourceChannel.read(buffer).also { bytesRead = it } > 0) {
+                                buffer.flip()
+                                targetChannel.write(buffer)
+                                buffer.compact()
+
+                                bytesCopied += bytesRead
+
+                                val fileProgress = if (fileSize > 0) {
+                                    bytesCopied.toFloat() / fileSize
+                                } else {
+                                    1f
+                                }
+
+                                withContext(Dispatchers.Main) {
+                                    onProgressUpdate(relativePath.toString(), fileProgress, filesMoved, totalFiles)
+                                }
+                            }
+
+                            targetChannel.force(true)
+                        }
+                    }
+
+                    Files.delete(sourcePath)
+                    withContext(Dispatchers.Main) {
+                        onProgressUpdate(relativePath.toString(), 1f, filesMoved++, totalFiles)
+                    }
+                }
+            }
+
+            Files.walkFileTree(
+                sourcePath,
+                object : SimpleFileVisitor<Path>() {
+                    override fun postVisitDirectory(dir: Path, exc: IOException?): FileVisitResult {
+                        if (exc == null) {
+                            try {
+                                var isEmpty = true
+                                Files.newDirectoryStream(dir).use { stream ->
+                                    if (stream.iterator().hasNext()) {
+                                        isEmpty = false
+                                    }
+                                }
+
+                                if (isEmpty && (dir != sourcePath)) {
+                                    Files.delete(dir)
+                                }
+                            } catch (e: Exception) {
+                                Timber.e(e, "Failed to delete directory: $dir")
+                            }
+                        }
+                        return FileVisitResult.CONTINUE
+                    }
+                },
+            )
+
+            try {
+                var isEmpty = true
+                Files.newDirectoryStream(sourcePath).use { stream ->
+                    if (stream.iterator().hasNext()) {
+                        isEmpty = false
+                    }
+                }
+
+                if (isEmpty) {
+                    Files.delete(sourcePath)
+                }
+            } catch (e: Exception) {
+                Timber.e(e)
+            }
+
+            withContext(Dispatchers.Main) {
+                onComplete()
+            }
+        } catch (e: Exception) {
+            Timber.e(e)
+            withContext(Dispatchers.Main) {
+                onComplete()
+            }
         }
     }
 }

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -273,6 +273,9 @@
     <string name="toast_failed_log_save">Kunne ikke gemme logcat på destinationen</string>
     <string name="toast_settings_activate">Lang klik for at aktivere</string>
 
+    <!-- Snack -->
+    <string name="snack_permissions_needed">Tilladelse er nødvendig for at få adgang til eksternt lager</string>
+
     <!-- Settings -->
     <string name="settings_allowed_orientations_subtitle">Vælg, hvilke retninger der kan roteres til, når du er i spillet</string>
     <string name="settings_allowed_orientations_title">Tilladte orienteringer</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -284,6 +284,9 @@
     <string name="toast_failed_log_save">Impossibile salvare il logcat nella destinazione</string>
     <string name="toast_settings_activate">Tieni premuto per attivare</string>
 
+    <!-- Snack -->
+    <string name="snack_permissions_needed">È necessario il permesso per accedere alla memoria esterna</string>
+
     <!-- Settings -->
     <string name="settings_allowed_orientations_subtitle">Scegli quali orientazioni possono essere ruotate durante il gioco</string>
     <string name="settings_allowed_orientations_title">Orientamenti consentiti</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -94,6 +94,7 @@
     <string name="value">Value</string>
     <string name="width">Width</string>
     <string name="yes">Yes</string>
+    <string name="uninstalling">Uninstalling…</string>
 
     <!-- Box 86 || Box 64 -->
     <string name="box64_name_label">Preset name</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -283,6 +283,9 @@
     <string name="toast_failed_log_save">Failed to save logcat to destination</string>
     <string name="toast_settings_activate">Long click to activate</string>
 
+    <!-- Snack -->
+    <string name="snack_permissions_needed">Permission is needed access external storage</string>
+
     <!-- Settings -->
     <string name="settings_allowed_orientations_subtitle">Choose which orientations can be rotated to when in-game</string>
     <string name="settings_allowed_orientations_title">Allowed Orientations</string>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,14 +23,14 @@ material3Adaptive = "1.1.0" # https://mvnrepository.com/artifact/androidx.compos
 material3AdaptiveNavSuite = "1.3.1" # https://mvnrepository.com/artifact/androidx.compose.material3/material3-adaptive-navigation-suite
 materialKolor = "2.0.2" # https://mvnrepository.com/artifact/com.materialkolor/material-kolor-android
 navigation-compose = "2.8.9" # https://mvnrepository.com/artifact/androidx.navigation/navigation-compose
-protobuf = "4.29.3" # https://mvnrepository.com/artifact/com.google.protobuf/protobuf-java
+protobuf = "4.30.2" # https://mvnrepository.com/artifact/com.google.protobuf/protobuf-java
 room-runtime = "2.6.1" # https://mvnrepository.com/artifact/androidx.room/room-runtime
 runner = "1.6.2" # https://mvnrepository.com/artifact/androidx.test/runner
 settings = "2.10.0" # https://github.com/alorma/Compose-Settings/releases
 spongycastle = "1.58.0.0" # https://mvnrepository.com/artifact/com.madgag.spongycastle/prov
 steamkit = "1.6.1-SNAPSHOT" # https://mvnrepository.com/artifact/in.dragonbra/javasteam
 timber = "5.0.1" # https://mvnrepository.com/artifact/com.jakewharton.timber/timber
-zstd-jni = "1.5.7-1" # https://mvnrepository.com/artifact/com.github.luben/zstd-jni
+zstd-jni = "1.5.7-3" # https://mvnrepository.com/artifact/com.github.luben/zstd-jni
 zxing = "3.5.3" # https://mvnrepository.com/artifact/com.google.zxing/core
 
 [libraries]
@@ -83,7 +83,7 @@ androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-man
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 
 # Dependencies when locally building JavaSteam
-commons-io = { module = "commons-io:commons-io", version = "2.18.0" } # https://mvnrepository.com/artifact/commons-io/commons-io
+commons-io = { module = "commons-io:commons-io", version = "2.19.0" } # https://mvnrepository.com/artifact/commons-io/commons-io
 commons-lang3 = { module = "org.apache.commons:commons-lang3", version = "3.17.0" } # https://mvnrepository.com/artifact/org.apache.commons/commons-lang3
 commons-validator = { module = "commons-validator:commons-validator", version = "1.9.0" } # https://mvnrepository.com/artifact/commons-validator/commons-validator
 ktor-engine = { module = "io.ktor:ktor-client-cio", version = "3.0.3" } # https://mvnrepository.com/artifact/io.ktor/ktor-client-cio

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -16,7 +16,7 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
-        maven { url = uri("https://oss.sonatype.org/content/repositories/snapshots") } // JavaSteam
+        maven { url = uri("https://central.sonatype.com/repository/maven-snapshots/") } // JavaSteam
     }
 }
 

--- a/ubuntufs/build.gradle.kts
+++ b/ubuntufs/build.gradle.kts
@@ -7,8 +7,7 @@ android {
     compileSdk = 35
 
     defaultConfig {
-        minSdk = 29
-        // testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        minSdk = 28
     }
 
     buildTypes {


### PR DESCRIPTION
This PR lowers the minimum api to 28 allowing Pluvia to store games to the SD card (user storage). 

The path is hard coded right now to a "Pluvia" folder as making a chooser dialog is a bit more work than I'd like to put in for this. 

- Games now download to SD card.
- Implementation to migrate existing games out of internal data folder.
- Ask permissions before downloading or migrating games.
- More logging breadcrumbs
- Rework Library Game filtering to be one shot instead of sequential filtering. 