### PR TITLE
Enable FPS overlay. 

### DIFF
--- a/app/src/main/java/com/OxGames/Pluvia/ui/screen/xserver/XServerViewModel.kt
+++ b/app/src/main/java/com/OxGames/Pluvia/ui/screen/xserver/XServerViewModel.kt
@@ -345,6 +345,9 @@ class XServerViewModel @Inject constructor(
             if (!envVars.has("WINEESYNC")) {
                 envVars.put("WINEESYNC", "1")
             }
+            if (state.value.graphicsDriver == "virgl") {
+                envVars.put("WINEESYNC", "0")
+            }
 
             // Timber.d("3 Container drives: ${container.drives}")
             val bindingPaths = mutableListOf<String>()

--- a/app/src/main/java/com/OxGames/Pluvia/ui/screen/xserver/XServerViewModel.kt
+++ b/app/src/main/java/com/OxGames/Pluvia/ui/screen/xserver/XServerViewModel.kt
@@ -336,6 +336,11 @@ class XServerViewModel @Inject constructor(
             guestProgramLauncherComponent.isWoW64Mode = wow64Mode
             guestProgramLauncherComponent.guestExecutable = guestExecutable
 
+            if (container.isShowFPS) {
+                envVars.put("GALLIUM_HUD", "simple,fps")
+                envVars.put("DXVK_HUD", "fps")
+            }
+
             envVars.putAll(container.envVars)
             if (!envVars.has("WINEESYNC")) {
                 envVars.put("WINEESYNC", "1")


### PR DESCRIPTION
Inplements FPS overlay in the top left corner for games that launch. 

@oxters168 you said you had issues with `WINEESYNC 0` for virgl. Is this still true?