### PR TITLE
fix: Corrected pathing issue

### DIFF
--- a/app/src/main/java/com/OxGames/Pluvia/enums/PathType.kt
+++ b/app/src/main/java/com/OxGames/Pluvia/enums/PathType.kt
@@ -86,6 +86,8 @@ enum class PathType {
         }
 
     companion object {
+        val DEFAULT = PathType.GameInstall
+
         fun from(keyValue: String?): PathType {
             return when (keyValue?.lowercase()) {
                 "%${GameInstall.name.lowercase()}%",

--- a/app/src/main/java/com/OxGames/Pluvia/service/SteamAutoCloud.kt
+++ b/app/src/main/java/com/OxGames/Pluvia/service/SteamAutoCloud.kt
@@ -174,30 +174,6 @@ object SteamAutoCloud {
                 }
             }
 
-        // val hasHashConflictsOrRemoteMissingFiles: (Map<String, List<UserFileInfo>>, AppFileChangeList) -> Boolean =
-        //     { localUserFiles, fileList ->
-        //         localUserFiles.values.any {
-        //             it.any { localUserFile ->
-        //                 fileList.files.firstOrNull { cloudFile ->
-        //                     val cloudFilePath = getFilePrefixPath(cloudFile, fileList)
-        //
-        //                     val localFilePath = Paths.get(
-        //                         localUserFile.prefix,
-        //                         localUserFile.filename,
-        //                     ).pathString
-        //
-        //                     Timber.i("Comparing $cloudFilePath and $localFilePath")
-        //
-        //                     cloudFilePath == localFilePath
-        //                 }?.let {
-        //                     Timber.i("Comparing SHA of ${getFilePrefixPath(it, fileList)} and ${localUserFile.prefixPath}")
-        //                     Timber.i("[${it.shaFile.joinToString(", ")}]\n[${localUserFile.sha.joinToString(", ")}]")
-        //
-        //                     it.shaFile.contentEquals(localUserFile.sha)
-        //                 } != true
-        //             }
-        //         }
-        //     }
 
         val getLocalUserFilesAsPrefixMap: () -> Map<String, List<UserFileInfo>> = {
             appInfo.ufs.saveFilePatterns
@@ -245,23 +221,10 @@ object SteamAutoCloud {
             "$scheme${urlHost}$urlPath"
         }
 
-        // val prootTimestampToDate: (Long) -> Date = { originalTimestamp ->
-        //     val androidTimestamp = System.currentTimeMillis()
-        //     val prootTimestamp = getProotTime(steamInstance)
-        //     val timeDifference = androidTimestamp - prootTimestamp
-        //     val adjustedTimestamp = originalTimestamp + timeDifference
-        //
-        //     Timber.i("Android: $androidTimestamp, PRoot: $prootTimestamp, $originalTimestamp -> $adjustedTimestamp")
-        //
-        //     Date(adjustedTimestamp)
-        // }
-
         val downloadFiles: (AppFileChangeList, CoroutineScope) -> Deferred<UserFilesDownloadResult> = { fileList, parentScope ->
             parentScope.async {
                 var filesDownloaded = 0
                 var bytesDownloaded = 0L
-
-                // val convertedPrefixes = convertPrefixes(fileList)
 
                 fileList.files.forEach { file ->
                     val prefixedPath = getFilePrefixPath(file, fileList)

--- a/app/src/main/java/com/OxGames/Pluvia/service/SteamAutoCloud.kt
+++ b/app/src/main/java/com/OxGames/Pluvia/service/SteamAutoCloud.kt
@@ -65,10 +65,13 @@ object SteamAutoCloud {
         val getPathTypePairs: (AppFileChangeList) -> List<Pair<String, String>> = { fileList ->
             fileList.pathPrefixes
                 .map {
-                    val matchResults = Regex("%\\w+%").findAll(it).map { it.value }.toList()
+                    var matchResults = Regex("%\\w+%").findAll(it).map { it.value }.toList()
 
                     Timber.i("Mapping prefix $it and found $matchResults")
 
+                    if(matchResults.size == 0){
+                        matchResults = List(1) {PathType.GameInstall.name}
+                    }
                     matchResults
                 }
                 .flatten()
@@ -81,6 +84,12 @@ object SteamAutoCloud {
 
             fileList.pathPrefixes.map { prefix ->
                 var modified = prefix
+
+                val prefixContainsPlaceholder = Regex("%\\w+%").findAll(prefix).any()
+
+                if(!prefixContainsPlaceholder){
+                    modified = Paths.get(PathType.GameInstall.name, prefix).pathString
+                }
 
                 pathTypePairs.forEach {
                     modified = modified.replace(it.first, it.second)

--- a/app/src/main/java/com/OxGames/Pluvia/service/SteamAutoCloud.kt
+++ b/app/src/main/java/com/OxGames/Pluvia/service/SteamAutoCloud.kt
@@ -89,9 +89,9 @@ object SteamAutoCloud {
             fileList.pathPrefixes.map { prefix ->
                 var modified = prefix
 
-                val prefixContainsPlaceholder = findPlaceholderWithin(prefix).any()
+                val prefixContainsNoPlaceholder = findPlaceholderWithin(prefix).none()
 
-                if(!prefixContainsPlaceholder){
+                if(prefixContainsNoPlaceholder){
                     modified = Paths.get(PathType.DEFAULT.name, prefix).pathString
                 }
 

--- a/app/src/main/java/com/OxGames/Pluvia/service/SteamAutoCloud.kt
+++ b/app/src/main/java/com/OxGames/Pluvia/service/SteamAutoCloud.kt
@@ -49,10 +49,9 @@ object SteamAutoCloud {
 
     private const val MAX_USER_FILE_RETRIES = 3
 
-    private fun findPlaceholderWithin (aString: String): Sequence<MatchResult> {
+    private fun findPlaceholderWithin(aString: String): Sequence<MatchResult> {
         return Regex("%\\w+%").findAll(aString)
     }
-
     fun syncUserFiles(
         appInfo: SteamApp,
         clientId: Long,
@@ -73,8 +72,8 @@ object SteamAutoCloud {
 
                     Timber.i("Mapping prefix $it and found $matchResults")
 
-                    if(matchResults.isEmpty()){
-                        matchResults = List(1) {PathType.DEFAULT.name}
+                    if (matchResults.isEmpty()) {
+                        matchResults = List(1) { PathType.DEFAULT.name }
                     }
                     matchResults
                 }
@@ -91,7 +90,7 @@ object SteamAutoCloud {
 
                 val prefixContainsNoPlaceholder = findPlaceholderWithin(prefix).none()
 
-                if(prefixContainsNoPlaceholder){
+                if (prefixContainsNoPlaceholder) {
                     modified = Paths.get(PathType.DEFAULT.name, prefix).pathString
                 }
 
@@ -173,7 +172,6 @@ object SteamAutoCloud {
                     } == true
                 }
             }
-
 
         val getLocalUserFilesAsPrefixMap: () -> Map<String, List<UserFileInfo>> = {
             appInfo.ufs.saveFilePatterns

--- a/app/src/main/java/com/OxGames/Pluvia/service/SteamService.kt
+++ b/app/src/main/java/com/OxGames/Pluvia/service/SteamService.kt
@@ -1155,7 +1155,7 @@ class SteamService : Service(), IChallengeUrlChanged {
                 Timber.w("Failed to connect to Steam, marking endpoint bad and force disconnecting")
 
                 try {
-                    steamClient!!.servers.tryMark(steamClient!!.currentEndpoint, PROTOCOL_TYPES, ServerQuality.BAD)
+                    steamClient!!.servers.tryMark(steamClient!!.currentEndPoint, PROTOCOL_TYPES, ServerQuality.BAD)
                 } catch (e: Exception) {
                     Timber.e(e, "Failed to mark endpoint as bad:")
                 }


### PR DESCRIPTION
1) Added a 'default' Path to the PathTypes enum class, the GameInstall path
2) Added checks in the SteamAutoCloud service to add the default path placeholder to any prefixes that don't contain placeholders
3) Fixed the reference of 'currentEndPoint' preventing the app running(casing issue)

Housekeeping:
- removed commented code
- moved placeholder regex check to a private function as it's now referenced in multiple places